### PR TITLE
docs: add CODE_OF_CONDUCT, SECURITY, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog
+
+All notable changes to **xiReactor Brilliant** are documented in this file.
+
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
+> **Note:** Release notes with richer context (migration steps, breaking-change rationale,
+> contributor credits) live on the [GitHub Releases page](https://github.com/thejeremyhodge/xireactor-brilliant/releases).
+> This file is a terse, machine-friendly index that mirrors those releases.
+
+## [Unreleased]
+
+### Added
+- _nothing yet_
+
+### Changed
+- _nothing yet_
+
+### Fixed
+- _nothing yet_
+
+## [0.2.1] — 2026-04-14
+
+### Fixed
+- `tests/demo_e2e.sh` API contract drift
+- README tweaks
+
+### Documentation
+- Added "For Maintainers" note to `CONTRIBUTING.md`
+- Extended `.gitignore` to cover private maintainer surfaces
+
+[Full notes](https://github.com/thejeremyhodge/xireactor-brilliant/releases/tag/v0.2.1)
+
+## [0.2.0] — 2026-04-14 — Brilliant rebrand + 4 days of upstream work
+
+### Added
+- Brilliant rebrand across README, docs, and package metadata
+- Write-path `entry_links` sync — POST / PUT on entries repopulates the `entry_links`
+  table from `[[wiki-link]]` references so traversal and render stay in lockstep (spec 0030)
+- Permissions v2 — unified polymorphic `permissions` table with user + group principals,
+  superseding the legacy entry/path permission tables (spec 0026)
+- Comments subsystem — threaded comments with resolve/escalate workflow, author-kind
+  tracking, and audit-log integration (API-only surface) (spec 0026)
+- Content type registry — canonical types with alias support, server-side validation at
+  submission time
+- Render-time wiki-link resolution — GET `/entries/{id}` rewrites `[[slug]]` →
+  `[Title](/kb/{id})` markdown, with frontmatter strip for imported vault content (spec 0028)
+- Skill bundle — Claude Co-work skill with inbox/outbox workflow and KB-aware session
+  bootstrap (spec 0029)
+- 4-tier governance pipeline on staging writes
+- Documented `main` / `dev` branching model in `CONTRIBUTING.md`
+- Getting Started section rebuilt in README
+
+[Full notes](https://github.com/thejeremyhodge/xireactor-brilliant/releases/tag/v0.2.0)
+
+## [0.1.0] — Initial public release
+
+First public drop of xiReactor Brilliant. Core entry CRUD, full-text search, wiki-link
+traversal via recursive CTEs, multi-tenant organizations with row-level security,
+MCP integration for Claude Co-work and Claude Code (stdio + Streamable HTTP / OAuth 2.1),
+and Obsidian vault import with preview, collision detection, and batch rollback.
+
+[Unreleased]: https://github.com/thejeremyhodge/xireactor-brilliant/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/thejeremyhodge/xireactor-brilliant/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/thejeremyhodge/xireactor-brilliant/releases/tag/v0.2.0
+[0.1.0]: https://github.com/thejeremyhodge/xireactor-brilliant/commit/6dcc794

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at the project maintainer via [GitHub private vulnerability reporting](https://github.com/thejeremyhodge/xireactor-brilliant/security/advisories/new) (the same private channel documented in CONTRIBUTING.md). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,64 @@
+# Security Policy
+
+## Supported Versions
+
+xiReactor Brilliant is pre-1.0. Security patches are issued against the latest tagged release on `main` only. Older tags are not backported.
+
+| Version | Supported |
+|---------|-----------|
+| 0.2.x   | ✅ (latest) |
+| < 0.2   | ❌         |
+
+## Reporting a Vulnerability
+
+**Please do not open public GitHub issues for security reports.**
+
+Use [GitHub's private vulnerability reporting](https://github.com/thejeremyhodge/xireactor-brilliant/security/advisories/new) to submit a report. This creates a private advisory visible only to the maintainers.
+
+Alternatively, email the maintainer directly (contact listed on the maintainer's GitHub profile).
+
+### What to include
+
+- A description of the issue and the impact
+- Steps to reproduce (minimum viable repro preferred)
+- The affected version, tag, or commit SHA
+- Any proof-of-concept code or logs you can share safely
+
+### What to expect
+
+- **Acknowledgement**: within 72 hours
+- **Initial assessment**: within 7 days
+- **Fix / mitigation timeline**: communicated after triage; varies by severity
+- **Disclosure**: coordinated via the GitHub advisory. Reporters who want credit will be named in the advisory and release notes. Anonymous reports are also welcome.
+
+## Scope
+
+In scope:
+
+- The `api/` FastAPI service and its auth/permissions surface
+- The `mcp/` server (stdio + Streamable HTTP / OAuth 2.1)
+- The database layer (`db/migrations/`), especially RLS policies and permission grants
+- The `tools/vault_import.py` ingestion path
+- Supply-chain concerns in `requirements.txt` / `Dockerfile`s published under this repo
+
+Out of scope:
+
+- Issues in third-party dependencies that are already tracked upstream (please report those to the upstream project; we'll pick up the fix on our next release)
+- Social-engineering attacks against maintainers or contributors
+- Denial-of-service via unreasonable load against a self-hosted instance (operator responsibility)
+- Findings that require physical access or root on the host
+- Findings against the demo credentials shipped in `tests/demo_e2e.sh` — these are intentionally public seed keys for local dev
+
+## Hardening Notes for Operators
+
+A few deployment choices materially affect your security posture:
+
+- **Change `ADMIN_PASSWORD`** from the `change-me-before-first-run` placeholder before exposing the API beyond `localhost`
+- **Rotate `ADMIN_API_KEY`** after first boot if you let it auto-generate
+- **Do not reuse the demo API keys** (`bkai_*_testkey_*`) outside of local dev — they are public
+- **Scope `ANTHROPIC_API_KEY`** to the Tier 3 reviewer use case; use a project-scoped key, not an org-wide key
+- **Put the API behind a reverse proxy** with TLS and rate-limiting before exposing to the internet; `docker-compose.yml` binds to `0.0.0.0` by default
+
+## Acknowledgements
+
+Reporters who responsibly disclose issues will be credited in the published advisory and the `CHANGELOG.md` entry for the release that ships the fix, unless they request anonymity.


### PR DESCRIPTION
Companion to #1. Three low-risk documentation additions — no code or behavioral changes.

## What's in this PR

| File | What | Why |
|---|---|---|
| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1 (canonical, unmodified body) | Community norms + unblocks GitHub Community Standards |
| `SECURITY.md` | Formal vulnerability-reporting policy | Surfaces the "Security" tab on GitHub and gives scanners a stable target |
| `CHANGELOG.md` | [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) index of v0.1.0 / v0.2.0 / v0.2.1 | Machine-friendly index; full notes still live on GitHub Releases |

All three are pure additions. Nothing in the tracked source is modified.

## Why each one

### `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1

A Code of Conduct is the single public document that sets community norms and gives maintainers a neutral reference point when they need to moderate. Without one:

- GitHub's **Community Standards** check stays incomplete, which is a small but visible signal to drive-by evaluators ("is this project professionally run?").
- Some companies' **OSS-use policies** block or delay adoption of repos that lack a CoC.
- First-time contributors have no signal about what behavior the project expects or won't tolerate, so they default to assumptions — which go both ways.
- When the first bad interaction happens, you have to moderate *without* a document to cite, which puts the maintainer in an awkward position.

I used **Contributor Covenant 2.1** verbatim (canonical text pulled from `EthicalSource/contributor_covenant`, not regenerated) because it's the de-facto standard — adopted by Kubernetes, Rails, Node.js, Linux Kernel (adapted), and ~40k public repos. Using the standard text means contributors who've agreed to it elsewhere don't re-read it, and you get the benefit of all the thought that went into the wording.

**Contact routing:** I filled the `[INSERT CONTACT METHOD]` placeholder with the same **GitHub private vulnerability reporting** URL that CONTRIBUTING.md already points to. This gives you one private inbox for both security and conduct reports instead of two. If you prefer a separate email for conduct reports, just swap the link — the rest of the file is canonical and shouldn't need edits.

### `SECURITY.md`

Your CONTRIBUTING.md already has a good security paragraph pointing to GitHub private vulnerability reporting — but GitHub's **"Security" tab** only activates when a file named `SECURITY.md` exists at the repo root or in `.github/`. Until this tab lights up:

- The "Report a vulnerability" button isn't shown in the repo header
- `securityPolicyUrl` in the API is empty (I verified via `gh repo view --json securityPolicyUrl`)
- Automated scanners (OSS Review Toolkit, Scorecard, etc.) score the project lower on the "has a disclosure policy" check
- Researchers scanning the repo have no standard place to look

This `SECURITY.md` formalizes what you already decided informally and adds:

- **Supported versions** table (0.2.x only; below 0.2 unsupported) — sets expectations so you're not on the hook for backports you never intended
- **Response SLAs** (72 h ack, 7 d initial assessment) — these are intentionally conservative; tighten if you prefer
- **Scope / out-of-scope** — explicitly calls out the demo `bkai_*_testkey_*` keys as intentionally public so researchers don't waste time reporting them
- **Operator hardening notes** — a short list of self-hosting gotchas (change `ADMIN_PASSWORD`, rotate `ADMIN_API_KEY`, don't reuse demo keys, etc.)

Nothing in here commits you to behavior beyond what's reasonable for a pre-1.0 solo-maintainer project.

### `CHANGELOG.md`

You're currently using **GitHub Releases** as your changelog, which is defensible — the notes are good and the UI is nice. The tradeoffs:

- Tooling (semantic-release, release-please, Dependabot's "view changelog" link, package managers like `pip`, `renovate`, etc.) all look for `CHANGELOG.md` at the repo root first. When it's missing, they either show nothing or scrape release notes heuristically.
- Users browsing the repo on GitHub see release notes only if they click through to the Releases page; `CHANGELOG.md` renders inline on the front page.
- Offline clones (which, for a self-hosted KB, is a real audience) lose all release history unless `CHANGELOG.md` is present.
- Search engines index `CHANGELOG.md` at a stable URL; release pages move.

**Format:** [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) — the format the tooling listed above expects. The structure (`Added` / `Changed` / `Fixed` / `Security` headers per version, reverse-chronological, semver-tagged) is what every changelog consumer is looking for.

**Approach to "source of truth":** I kept the `CHANGELOG.md` entries terse and **linked each version back to the GitHub Release** for the full notes. That way:

- You don't have to maintain two copies of every release note
- The richer context you already wrote (migration steps, contributor thanks, etc.) stays on GitHub Releases where you write it
- The machine-friendly index exists at the standard location for tools and offline readers

Future releases: just append a new `## [x.y.z]` section at the top, list the highlights in the Keep-a-Changelog buckets, and link to the full release page. Takes maybe 2 minutes per release.

## What this PR is NOT doing

- Not touching any code
- Not adding CI, workflows, or branch protection
- Not touching `CONTRIBUTING.md`, `README.md`, `LICENSE`, `.gitignore`, or any existing file
- Not adding `CLAUDE.md`, `AGENTS.md`, `.editorconfig`, or other files from the broader checklist in #1

If you want any of those, happy to send them as individually-mergeable follow-ups — just drop a note on #1.

## How to review

```bash
gh pr checkout <this-pr>
# Read the three new files, that's the whole diff:
cat CODE_OF_CONDUCT.md SECURITY.md CHANGELOG.md
```

Merge target is `dev` per your branching model in `CONTRIBUTING.md`.

Close this if it's not useful — no offense taken 🙏

---
*Opened by jeremylongshore as a good-faith contribution. See #1 for the full audit and offer to PR additional items.*