### PR TITLE
feat(observability): per-request + per-entry usage analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Brilliant ships with an MCP server (`mcp/`) and a Claude skill (`skill/`) for Cl
 | Obsidian vault import | Shipped |
 | Tier 3 AI reviewer (Anthropic) | Shipped, opt-in via ANTHROPIC_API_KEY |
 | KB-native review escalation | Shipped |
+| Observability + MCP usage analytics | Shipped in v0.3.0 — see [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) |
 | Concurrent writer stress test | 20–120 clients, ~178 ops/sec, 99.8%+ success, 0 data corruption (see below) |
 | Production Docker compose | Dev only — bring your own reverse proxy |
 | Web frontend | Planned (separate repo) |

--- a/api/auth.py
+++ b/api/auth.py
@@ -112,6 +112,12 @@ async def get_current_user(request: Request) -> UserContext:
 
         source = _KEY_TYPE_TO_SOURCE.get(key_type, "api")
 
+        # Stash on request.state so downstream middleware (e.g. request_log)
+        # can read org and actor IDs after the handler returns. Safe to set
+        # even if no middleware reads them.
+        request.state.user_org_id = str(org_id)
+        request.state.user_id = str(user_id)
+
         return UserContext(
             id=str(user_id),
             org_id=str(org_id),

--- a/api/main.py
+++ b/api/main.py
@@ -7,6 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from database import init_pool, close_pool, get_pool
 from admin_bootstrap import ensure_admin_user
+from middleware.request_log import RequestLogMiddleware
 
 
 @asynccontextmanager
@@ -35,6 +36,11 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Request logger — added AFTER CORS so it becomes the outermost middleware
+# (Starlette prepends on add_middleware + reverses on build, so last-added
+# wraps everything). This lets us time the full stack including CORS + auth.
+app.add_middleware(RequestLogMiddleware)
+
 
 @app.get("/health")
 async def health():
@@ -61,6 +67,7 @@ _route_modules = [
     ("routes.groups", "groups_router", "/groups"),
     ("routes.comments", "entries_comments_router", "/entries"),
     ("routes.comments", "comments_router", "/comments"),
+    ("routes.analytics", "router", "/analytics"),
 ]
 
 for module_path, attr_name, prefix in _route_modules:

--- a/api/middleware/request_log.py
+++ b/api/middleware/request_log.py
@@ -1,0 +1,160 @@
+"""Fire-and-forget request logging middleware.
+
+For every request (except /health and /static/*), records:
+    endpoint (path template), method, status, response_bytes, approx_tokens,
+    duration_ms, org_id, actor_id
+
+Inserts into request_log via asyncio.create_task so the client response is
+never blocked on the DB write. All exceptions in the background task are
+swallowed — a logging failure must never surface as a client-visible error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from typing import Any
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.routing import Route
+from starlette.types import ASGIApp
+
+from database import get_pool
+
+logger = logging.getLogger(__name__)
+
+# Safe identifier pattern for SET LOCAL values (matches database._SAFE_VALUE)
+_SAFE_VALUE = re.compile(r"^[\w\-\.]+$")
+
+_MAX_ENDPOINT_LEN = 256
+
+
+def _resolve_endpoint(request: Request) -> str:
+    """Return the matched route's path template, or raw path as fallback.
+
+    When FastAPI/Starlette has matched a route, `request.scope["route"]` is
+    a `starlette.routing.Route` with `.path` = "/entries/{entry_id}". This
+    is preferable to the raw URL so IDs don't explode cardinality.
+    """
+    route = request.scope.get("route")
+    if isinstance(route, Route):
+        path = route.path
+    else:
+        path = request.url.path
+    if len(path) > _MAX_ENDPOINT_LEN:
+        path = path[:_MAX_ENDPOINT_LEN]
+    return path
+
+
+def _should_skip(path: str) -> bool:
+    """Return True if this path should not be logged."""
+    if path == "/health":
+        return True
+    if path.startswith("/static"):
+        return True
+    return False
+
+
+async def _log_request(
+    *,
+    org_id: str | None,
+    actor_id: str | None,
+    endpoint: str,
+    method: str,
+    status: int,
+    response_bytes: int | None,
+    approx_tokens: int | None,
+    duration_ms: int,
+) -> None:
+    """Insert one row into request_log under a kb_admin-scoped connection.
+
+    The request may be unauthenticated (no org_id). The RLS INSERT policy
+    on request_log accepts org_id IS NULL or org_id = current_setting('app.org_id').
+    When an org_id is present we scope app.org_id so the policy's second
+    branch also accepts authenticated inserts.
+
+    All exceptions are swallowed — a logging failure must never surface.
+    """
+    try:
+        pool = get_pool()
+        async with pool.connection() as conn:
+            async with conn.transaction():
+                await conn.execute("SET LOCAL ROLE kb_admin")
+                if org_id is not None and _SAFE_VALUE.match(str(org_id)):
+                    await conn.execute(
+                        f"SET LOCAL app.org_id = '{org_id}'"
+                    )
+                await conn.execute(
+                    """
+                    INSERT INTO request_log
+                        (org_id, actor_id, endpoint, method, status,
+                         response_bytes, approx_tokens, duration_ms)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        org_id,
+                        actor_id,
+                        endpoint,
+                        method,
+                        status,
+                        response_bytes,
+                        approx_tokens,
+                        duration_ms,
+                    ),
+                )
+    except Exception as exc:  # noqa: BLE001 — intentional catch-all
+        logger.warning("request_log insert failed: %s", exc)
+
+
+class RequestLogMiddleware(BaseHTTPMiddleware):
+    """ASGI middleware that logs every request to the request_log table.
+
+    Installs above CORS so that the timing includes the full stack including
+    authentication. /health and /static/* are skipped.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next: Any):
+        start = time.perf_counter()
+        response = await call_next(request)
+        duration_ms = int((time.perf_counter() - start) * 1000)
+
+        endpoint = _resolve_endpoint(request)
+        if _should_skip(endpoint):
+            return response
+
+        # Response size — content-length header if present.
+        content_length = response.headers.get("content-length")
+        try:
+            response_bytes = int(content_length) if content_length else None
+        except (TypeError, ValueError):
+            response_bytes = None
+        approx_tokens = response_bytes // 4 if response_bytes else None
+
+        # Pull auth context stashed by get_current_user. Missing => unauthenticated.
+        org_id = getattr(request.state, "user_org_id", None)
+        actor_id = getattr(request.state, "user_id", None)
+
+        # Fire-and-forget: do NOT await.
+        try:
+            asyncio.create_task(
+                _log_request(
+                    org_id=org_id,
+                    actor_id=actor_id,
+                    endpoint=endpoint,
+                    method=request.method,
+                    status=response.status_code,
+                    response_bytes=response_bytes,
+                    approx_tokens=approx_tokens,
+                    duration_ms=duration_ms,
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 — never surface logging failures
+            logger.warning("request_log task scheduling failed: %s", exc)
+
+        return response

--- a/api/routes/analytics.py
+++ b/api/routes/analytics.py
@@ -1,0 +1,272 @@
+"""Admin-only usage analytics endpoints.
+
+Rolls up the observability tables (`entry_access_log`, `request_log`) into
+top-N shapes for admin consumption. All endpoints are:
+
+- admin-only (checked explicitly before any DB call, so non-admins get a
+  clean 403 rather than a silent 0-row result via RLS);
+- org-scoped by RLS (we run under the admin's RLS-scoped connection);
+- paginated (limit 1..200, offset >= 0).
+
+Response shapes are intentionally stable — downstream MCP tool (T-0192)
+and tests (T-0193) depend on them. Do not add extra keys without bumping
+the consumers.
+"""
+
+from datetime import timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from psycopg.rows import dict_row
+
+from auth import UserContext, get_current_user
+from database import get_db
+
+router = APIRouter(tags=["analytics"])
+
+
+# Map of accepted `since` tokens -> timedelta. Extend here if product asks
+# for e.g. `90d`; keep the set small so the surface stays predictable.
+_SINCE_MAP = {
+    "1h": timedelta(hours=1),
+    "24h": timedelta(hours=24),
+    "7d": timedelta(days=7),
+    "30d": timedelta(days=30),
+}
+
+
+def _parse_since(since: str) -> timedelta:
+    """Parse a `since` query param into a timedelta. 422 on unknown tokens."""
+    delta = _SINCE_MAP.get(since)
+    if delta is None:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Invalid 'since' value: {since!r}. "
+                f"Must be one of: {sorted(_SINCE_MAP.keys())}"
+            ),
+        )
+    return delta
+
+
+def _require_admin(user: UserContext) -> None:
+    """Gate: analytics endpoints are admin-only. 403 for everyone else."""
+    if user.role != "admin":
+        raise HTTPException(
+            status_code=403,
+            detail="analytics endpoints are admin-only",
+        )
+
+
+# Valid actor_type filter values for top-entries — matches the CHECK
+# constraint on `entry_access_log.actor_type`.
+_VALID_ACTOR_TYPES = {"user", "agent", "api"}
+
+
+@router.get("/top-entries")
+async def top_entries(
+    actor_type: str | None = Query(
+        None,
+        description="Filter by actor type: user, agent, or api",
+    ),
+    since: str = Query("24h", description="Time window: 1h, 24h, 7d, or 30d"),
+    limit: int = Query(20, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    user: UserContext = Depends(get_current_user),
+):
+    """Top entries by read count within the window, org-scoped.
+
+    Single GROUP BY query joining `entry_access_log` to `entries` so the
+    response includes titles without an N+1 fanout.
+    """
+    _require_admin(user)
+    delta = _parse_since(since)
+
+    if actor_type is not None and actor_type not in _VALID_ACTOR_TYPES:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Invalid 'actor_type': {actor_type!r}. "
+                f"Must be one of: {sorted(_VALID_ACTOR_TYPES)}"
+            ),
+        )
+
+    # Build the WHERE clause. The `ts >= now() - interval` bound is applied
+    # on the access log side where the idx_entry_access_org_ts index helps.
+    where_parts = ["eal.ts >= now() - %s::interval"]
+    params: list = [f"{int(delta.total_seconds())} seconds"]
+
+    if actor_type is not None:
+        where_parts.append("eal.actor_type = %s")
+        params.append(actor_type)
+
+    where_clause = " AND ".join(where_parts)
+
+    query = f"""
+        SELECT
+            eal.entry_id::text AS entry_id,
+            e.title AS title,
+            COUNT(*) AS reads
+        FROM entry_access_log eal
+        JOIN entries e ON e.id = eal.entry_id
+        WHERE {where_clause}
+        GROUP BY eal.entry_id, e.title
+        ORDER BY reads DESC, eal.entry_id
+        LIMIT %s OFFSET %s
+    """
+    params.extend([limit, offset])
+
+    async with get_db(user) as conn:
+        cur = await conn.execute(query, params)
+        cur.row_factory = dict_row
+        rows = await cur.fetchall()
+
+    # Coerce COUNT(*) (psycopg returns Decimal/int) to int for JSON clarity.
+    items = [
+        {
+            "entry_id": r["entry_id"],
+            "title": r["title"],
+            "reads": int(r["reads"]),
+        }
+        for r in rows
+    ]
+
+    return {
+        "items": items,
+        "limit": limit,
+        "offset": offset,
+        "since": since,
+    }
+
+
+@router.get("/top-endpoints")
+async def top_endpoints(
+    since: str = Query("24h", description="Time window: 1h, 24h, 7d, or 30d"),
+    limit: int = Query(20, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    user: UserContext = Depends(get_current_user),
+):
+    """Top endpoints by request count within the window, with avg + p95 duration."""
+    _require_admin(user)
+    delta = _parse_since(since)
+
+    query = """
+        SELECT
+            endpoint,
+            COUNT(*) AS count,
+            AVG(duration_ms)::float AS avg_duration_ms,
+            percentile_cont(0.95) WITHIN GROUP (ORDER BY duration_ms)::float
+                AS p95_duration_ms
+        FROM request_log
+        WHERE ts >= now() - %s::interval
+        GROUP BY endpoint
+        ORDER BY count DESC, endpoint
+        LIMIT %s OFFSET %s
+    """
+    params = [f"{int(delta.total_seconds())} seconds", limit, offset]
+
+    async with get_db(user) as conn:
+        cur = await conn.execute(query, params)
+        cur.row_factory = dict_row
+        rows = await cur.fetchall()
+
+    items = [
+        {
+            "endpoint": r["endpoint"],
+            "count": int(r["count"]),
+            "avg_duration_ms": (
+                float(r["avg_duration_ms"]) if r["avg_duration_ms"] is not None else None
+            ),
+            "p95_duration_ms": (
+                float(r["p95_duration_ms"]) if r["p95_duration_ms"] is not None else None
+            ),
+        }
+        for r in rows
+    ]
+
+    return {
+        "items": items,
+        "limit": limit,
+        "offset": offset,
+        "since": since,
+    }
+
+
+@router.get("/session-depth")
+async def session_depth(
+    actor_id: str = Query(..., description="The actor_id to profile"),
+    since: str = Query("24h", description="Time window: 1h, 24h, 7d, or 30d"),
+    user: UserContext = Depends(get_current_user),
+):
+    """Bucket an actor's activity into 15-minute windows.
+
+    A window row reports how many requests the actor issued, how many
+    distinct entries they touched (via entry_access_log joined on actor_id),
+    and the wall-clock span of requests within that window.
+    """
+    _require_admin(user)
+    delta = _parse_since(since)
+
+    # 15-minute bucket: truncate to the minute, then subtract (minute % 15).
+    # Same bucket expression used on both sides so the LEFT JOIN lines up.
+    bucket_expr = (
+        "date_trunc('minute', {ts}) "
+        "- (EXTRACT(MINUTE FROM {ts})::int %% 15) * interval '1 minute'"
+    )
+    req_bucket = bucket_expr.format(ts="rl.ts")
+    eal_bucket = bucket_expr.format(ts="eal.ts")
+
+    query = f"""
+        WITH req AS (
+            SELECT
+                {req_bucket} AS window_start,
+                COUNT(*) AS requests,
+                EXTRACT(EPOCH FROM (MAX(rl.ts) - MIN(rl.ts)))::int AS duration_s
+            FROM request_log rl
+            WHERE rl.actor_id = %s
+              AND rl.ts >= now() - %s::interval
+            GROUP BY window_start
+        ),
+        touched AS (
+            SELECT
+                {eal_bucket} AS window_start,
+                COUNT(DISTINCT eal.entry_id) AS entries_touched
+            FROM entry_access_log eal
+            WHERE eal.actor_id = %s
+              AND eal.ts >= now() - %s::interval
+            GROUP BY window_start
+        )
+        SELECT
+            COALESCE(req.window_start, touched.window_start) AS window_start,
+            COALESCE(req.requests, 0) AS requests,
+            COALESCE(touched.entries_touched, 0) AS entries_touched,
+            COALESCE(req.duration_s, 0) AS duration_s
+        FROM req
+        FULL OUTER JOIN touched ON touched.window_start = req.window_start
+        ORDER BY window_start
+    """
+
+    interval_str = f"{int(delta.total_seconds())} seconds"
+    params = [actor_id, interval_str, actor_id, interval_str]
+
+    async with get_db(user) as conn:
+        cur = await conn.execute(query, params)
+        cur.row_factory = dict_row
+        rows = await cur.fetchall()
+
+    windows = [
+        {
+            "window_start": (
+                r["window_start"].isoformat() if r["window_start"] is not None else None
+            ),
+            "requests": int(r["requests"]),
+            "entries_touched": int(r["entries_touched"]),
+            "duration_s": int(r["duration_s"]),
+        }
+        for r in rows
+    ]
+
+    return {
+        "actor_id": actor_id,
+        "windows": windows,
+        "since": since,
+    }

--- a/api/routes/entries.py
+++ b/api/routes/entries.py
@@ -16,6 +16,7 @@ from models import (
     EntryUpdate,
     VALID_SENSITIVITIES,
 )
+from services.access_log import log_entry_reads
 from services.links import sync_entry_links
 from services.render import resolve_wiki_links
 
@@ -190,6 +191,9 @@ async def get_entry(
             row["content"], conn, str(row["id"])
         )
 
+        # Observability: record the read. Failure is swallowed inside helper.
+        await log_entry_reads(conn, user, [str(row["id"])])
+
         return _row_to_response(row)
 
 
@@ -261,6 +265,9 @@ async def list_entries(
         cur = await conn.execute(data_query, data_params)
         cur.row_factory = dict_row
         rows = await cur.fetchall()
+
+        # Observability: batched INSERT for every entry surfaced in this page.
+        await log_entry_reads(conn, user, [str(r["id"]) for r in rows])
 
         return EntryList(
             entries=[_row_to_response(r) for r in rows],

--- a/api/routes/graph.py
+++ b/api/routes/graph.py
@@ -17,6 +17,7 @@ from psycopg.rows import dict_row
 from auth import UserContext, get_current_user
 from database import get_db
 from models import GraphEdge, GraphNode, GraphResponse
+from services.access_log import log_entry_reads
 
 router = APIRouter(tags=["graph"])
 
@@ -126,6 +127,11 @@ async def get_graph(
             edge_rows = await cur.fetchall()
         else:
             edge_rows = []
+
+        # Observability: single batched INSERT for all returned node ids.
+        # Inside the conn block so the INSERT runs under the caller's RLS
+        # context; helper swallows its own errors.
+        await log_entry_reads(conn, user, node_ids)
 
     nodes = [
         GraphNode(

--- a/api/routes/links.py
+++ b/api/routes/links.py
@@ -14,6 +14,7 @@ from models import (
     TraversalResponse,
     VALID_LINK_TYPES,
 )
+from services.access_log import log_entry_reads
 
 router = APIRouter(tags=["links"])
 
@@ -203,6 +204,13 @@ async def get_links(
             )
             for row in rows
         ]
+
+        # Observability: log the center entry + each neighbor in one batched INSERT.
+        await log_entry_reads(
+            conn,
+            user,
+            [entry_id, *(n.entry_id for n in neighbors)],
+        )
 
         return TraversalResponse(
             origin_id=entry_id,

--- a/api/routes/staging.py
+++ b/api/routes/staging.py
@@ -17,6 +17,7 @@ from models import (
     StagingResponse,
     StagingSubmit,
 )
+from services.access_log import log_entry_reads
 from services.ai_reviewer import review_staging_item
 
 router = APIRouter(tags=["staging"])
@@ -651,6 +652,14 @@ async def list_staging(
         )
         cur.row_factory = dict_row
         rows = await cur.fetchall()
+
+        # Observability: only log rows that surface a concrete target_entry_id.
+        # Staging items without one (e.g. pending creates) have no entry to log.
+        target_ids = [
+            str(r["target_entry_id"]) for r in rows if r.get("target_entry_id")
+        ]
+        if target_ids:
+            await log_entry_reads(conn, user, target_ids)
 
         return StagingList(
             items=[_row_to_response(r) for r in rows],

--- a/api/services/access_log.py
+++ b/api/services/access_log.py
@@ -1,0 +1,88 @@
+"""Batched per-entry read tracking helper for `entry_access_log`.
+
+Called from read-path endpoints in `routes/entries.py`, `routes/graph.py`, and
+`routes/staging.py` to record which entries the caller actually saw in the
+response. Writes participate in the caller's existing RLS-scoped transaction
+so the INSERT runs under the same pg role / `app.org_id` that served the read.
+
+Design notes:
+- One multi-row INSERT per request (even for 50-entry list pages or big graphs)
+  so we don't amplify query count. See spec 0034c / T-0190.
+- Failure is non-fatal: if logging errors, we warn and swallow. A logging
+  outage must NEVER break a read for the user.
+- `actor_type` maps from `UserContext.key_type`: agent keys → `agent`, human
+  (interactive) keys → `user`, machine/integration keys → `api`. The DB has a
+  CHECK constraint on those three values.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable
+
+logger = logging.getLogger(__name__)
+
+
+# UserContext.key_type -> entry_access_log.actor_type
+_ACTOR_TYPE_MAP = {
+    "agent": "agent",
+    "interactive": "user",
+    "api_integration": "api",
+}
+
+
+async def log_entry_reads(
+    conn: Any,
+    user: Any,
+    entry_ids: Iterable[str],
+) -> None:
+    """Record one `entry_access_log` row per distinct entry id surfaced.
+
+    Args:
+        conn: An RLS-scoped async psycopg connection from `get_db(user)`. The
+            caller's transaction is reused — do NOT open a new connection.
+        user: The authenticated `UserContext` for this request.
+        entry_ids: Entry ids that were returned to the caller. Duplicates are
+            collapsed while preserving first-seen order.
+
+    Never raises. Errors are logged at WARNING and swallowed so read paths
+    remain resilient to logging outages.
+    """
+    try:
+        # De-duplicate while preserving order
+        seen: set[str] = set()
+        unique_ids: list[str] = []
+        for eid in entry_ids:
+            if eid is None:
+                continue
+            sid = str(eid)
+            if sid in seen:
+                continue
+            seen.add(sid)
+            unique_ids.append(sid)
+
+        if not unique_ids:
+            return
+
+        actor_type = _ACTOR_TYPE_MAP.get(getattr(user, "key_type", None), "api")
+        org_id = user.org_id
+        actor_id = user.id
+        source = getattr(user, "source", None)
+
+        # One multi-row INSERT. Build VALUES placeholders dynamically so we
+        # flush all ids in a single round-trip regardless of list size.
+        placeholders = ",".join(["(%s, %s, %s, %s, %s)"] * len(unique_ids))
+        params: list[Any] = []
+        for eid in unique_ids:
+            params.extend([org_id, actor_type, actor_id, eid, source])
+
+        await conn.execute(
+            f"""
+            INSERT INTO entry_access_log
+                (org_id, actor_type, actor_id, entry_id, source)
+            VALUES {placeholders}
+            """,
+            params,
+        )
+    except Exception as exc:  # noqa: BLE001 — log-write must never break the read
+        logger.warning("entry_access_log write failed: %s", exc)

--- a/db/migrations/023_access_log.sql
+++ b/db/migrations/023_access_log.sql
@@ -1,0 +1,123 @@
+-- 023_access_log.sql
+-- Observability tables: per-entry read log + per-request log.
+--
+-- Both tables are admin-only SELECT (mirrors audit_log), admin can see all rows
+-- within their org; other roles cannot. All org-scoped via RLS. Append-only
+-- (no UPDATE/DELETE policies).
+--
+-- The API layer inserts rows from request middleware (request_log) and from
+-- decorated read paths (entry_access_log). All write paths run under a
+-- kb_admin-scoped connection for request_log (because the request may be
+-- unauthenticated — e.g. a 401 on a bad token) and reuse the current user's
+-- RLS-scoped connection for entry_access_log.
+--
+-- Depends on: 001_core.sql, 003_governance.sql, 004_rls.sql
+
+-- =============================================================================
+-- entry_access_log — one row per (actor, entry) surfaced in a read response
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS entry_access_log (
+    id          BIGSERIAL PRIMARY KEY,
+    org_id      TEXT NOT NULL,
+    actor_type  TEXT NOT NULL CHECK (actor_type IN ('user', 'agent', 'api')),
+    actor_id    TEXT NOT NULL,
+    entry_id    UUID NOT NULL,
+    source      TEXT,  -- web_ui | agent | api (nullable for compatibility)
+    ts          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_entry_access_org_ts
+    ON entry_access_log (org_id, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_entry_access_org_entry_ts
+    ON entry_access_log (org_id, entry_id, ts DESC);
+
+-- =============================================================================
+-- request_log — one row per HTTP request (excluding /health + /static)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS request_log (
+    id              BIGSERIAL PRIMARY KEY,
+    org_id          TEXT,              -- nullable: unauthenticated requests
+    actor_id        TEXT,              -- nullable: unauthenticated requests
+    endpoint        TEXT NOT NULL,     -- path template, truncated to <=256
+    method          TEXT NOT NULL,
+    status          INTEGER NOT NULL,
+    response_bytes  INTEGER,
+    approx_tokens   INTEGER,
+    duration_ms     INTEGER NOT NULL,
+    ts              TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_request_log_org_ts
+    ON request_log (org_id, ts DESC);
+CREATE INDEX IF NOT EXISTS idx_request_log_org_endpoint_ts
+    ON request_log (org_id, endpoint, ts DESC);
+
+-- =============================================================================
+-- GRANTS — mirror audit_log: all kb roles can INSERT; only kb_admin can SELECT
+-- (RLS policies enforce per-row scoping)
+-- =============================================================================
+
+-- SELECT granted to all roles; RLS policies below restrict rows so that
+-- only kb_admin actually sees anything (non-admin roles have no SELECT
+-- policy and FORCE RLS defaults to deny — 0 rows, no error).
+GRANT SELECT, INSERT ON entry_access_log
+    TO kb_admin, kb_editor, kb_commenter, kb_viewer, kb_agent;
+GRANT USAGE ON SEQUENCE entry_access_log_id_seq
+    TO kb_admin, kb_editor, kb_commenter, kb_viewer, kb_agent;
+
+GRANT SELECT, INSERT ON request_log
+    TO kb_admin, kb_editor, kb_commenter, kb_viewer, kb_agent;
+GRANT USAGE ON SEQUENCE request_log_id_seq
+    TO kb_admin, kb_editor, kb_commenter, kb_viewer, kb_agent;
+
+-- =============================================================================
+-- RLS — entry_access_log
+-- =============================================================================
+
+ALTER TABLE entry_access_log ENABLE ROW LEVEL SECURITY;
+ALTER TABLE entry_access_log FORCE ROW LEVEL SECURITY;
+
+-- Drop-and-recreate pattern for idempotency across re-applies.
+DROP POLICY IF EXISTS entry_access_log_select_admin ON entry_access_log;
+CREATE POLICY entry_access_log_select_admin ON entry_access_log
+    FOR SELECT
+    TO kb_admin
+    USING (org_id = current_setting('app.org_id'));
+
+-- INSERT policy: any kb role can insert within their org (or unauth → NULL).
+DROP POLICY IF EXISTS entry_access_log_insert ON entry_access_log;
+CREATE POLICY entry_access_log_insert ON entry_access_log
+    FOR INSERT
+    TO kb_admin, kb_editor, kb_commenter, kb_viewer, kb_agent
+    WITH CHECK (
+        org_id IS NULL
+        OR org_id = current_setting('app.org_id')
+    );
+
+-- No UPDATE or DELETE policies: append-only.
+
+-- =============================================================================
+-- RLS — request_log
+-- =============================================================================
+
+ALTER TABLE request_log ENABLE ROW LEVEL SECURITY;
+ALTER TABLE request_log FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS request_log_select_admin ON request_log;
+CREATE POLICY request_log_select_admin ON request_log
+    FOR SELECT
+    TO kb_admin
+    USING (org_id = current_setting('app.org_id'));
+
+DROP POLICY IF EXISTS request_log_insert ON request_log;
+CREATE POLICY request_log_insert ON request_log
+    FOR INSERT
+    TO kb_admin, kb_editor, kb_commenter, kb_viewer, kb_agent
+    WITH CHECK (
+        org_id IS NULL
+        OR org_id = current_setting('app.org_id')
+    );
+
+-- No UPDATE or DELETE policies: append-only.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,158 @@
+# Observability
+
+Brilliant records two kinds of telemetry so admins can answer "what is the team actually doing with the KB?" — per-request performance and per-entry reads. Both live in Postgres, both are admin-only by RLS, and both are queryable via the API and the `get_usage_stats` MCP tool.
+
+## Overview
+
+| Captured | Not captured |
+|---|---|
+| HTTP method, path template (`/entries/{entry_id}`, not raw IDs), status, duration, response size | Request bodies |
+| Which `entry_id` each read surfaced | Raw query strings beyond the pre-parsed template |
+| Authenticated `actor_id` (user ID, not email) and `org_id` | IP addresses |
+| Best-effort `approx_tokens = response_bytes // 4` | Full request/response payloads |
+
+Middleware is fire-and-forget: the request returns first, the log row is inserted from a background task. A logging failure is caught and logged as a stdlib warning — it cannot surface to the client.
+
+## Tables
+
+Both tables are append-only (no UPDATE/DELETE policies). Introduced in `db/migrations/023_access_log.sql`.
+
+### `entry_access_log`
+
+One row per (actor, entry) surfaced in a read response. Multi-entry responses (list, graph, neighbors) use a single batched INSERT per request.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `BIGSERIAL` | |
+| `org_id` | `TEXT` | RLS scope |
+| `actor_type` | `TEXT` | `user`, `agent`, `api` |
+| `actor_id` | `TEXT` | e.g. `usr_admin` |
+| `entry_id` | `UUID` | the entry that was read |
+| `source` | `TEXT` | `web_ui`, `agent`, `api` |
+| `ts` | `TIMESTAMPTZ` | default `now()` |
+
+Indexes: `(org_id, ts DESC)`, `(org_id, entry_id, ts DESC)`.
+
+### `request_log`
+
+One row per HTTP request, excluding `/health` and `/static/*`.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `BIGSERIAL` | |
+| `org_id` | `TEXT` (nullable) | `NULL` for unauthenticated requests |
+| `actor_id` | `TEXT` (nullable) | `NULL` for unauthenticated requests |
+| `endpoint` | `TEXT` | path template, truncated to ≤256 chars |
+| `method` | `TEXT` | |
+| `status` | `INTEGER` | |
+| `response_bytes` | `INTEGER` | from `Content-Length` when known |
+| `approx_tokens` | `INTEGER` | `response_bytes // 4` when known |
+| `duration_ms` | `INTEGER` | full stack (CORS + auth + handler) |
+| `ts` | `TIMESTAMPTZ` | default `now()` |
+
+Indexes: `(org_id, ts DESC)`, `(org_id, endpoint, ts DESC)`.
+
+## RLS
+
+Both tables `ENABLE ROW LEVEL SECURITY` and `FORCE ROW LEVEL SECURITY`. The only SELECT policy is `TO kb_admin USING (org_id = current_setting('app.org_id'))`. Non-admin roles have SELECT granted at the table level but no policy — FORCE RLS returns zero rows (rather than erroring) when a viewer/editor/commenter/agent tries to read.
+
+INSERT is open to all kb roles with `WITH CHECK (org_id IS NULL OR org_id = current_setting('app.org_id'))`. This lets an unauthenticated request still be logged (e.g. a 401 on a bad token), and keeps tenant isolation intact for everything else.
+
+## Privacy / PII
+
+- **Logged:** `actor_id` (the user ID string, not email). `org_id`. Path template. Status. Duration. Response size.
+- **Not logged:** IP addresses. Request bodies. Response bodies. Email addresses. Raw query strings beyond the parameter parsing that produced the path template.
+- **Per-tenant config:** not implemented yet. All tenants log the same fields. An `organizations.settings` flag to suppress actor_id capture is an obvious next step.
+- **`approx_tokens`:** a rough `bytes // 4` estimate. Not a replacement for a real tokenizer; useful as an order-of-magnitude proxy for cost attribution.
+
+## Retention
+
+No automatic retention is applied. Tables grow monotonically until an operator prunes them. A reasonable default would be **90 days** for both tables.
+
+Manual retention as a one-liner from the admin DSN:
+
+```sql
+DELETE FROM request_log WHERE ts < now() - interval '90 days';
+DELETE FROM entry_access_log WHERE ts < now() - interval '90 days';
+```
+
+Or schedule via `pg_cron` / external cron. A first-class retention toggle is on the roadmap.
+
+## Rollup endpoints
+
+All endpoints are admin-only (non-admin callers get a `403` before the DB is queried). All are org-scoped via RLS. `since` accepts `1h`, `24h`, `7d`, `30d`.
+
+### `GET /analytics/top-entries?actor_type=&since=24h&limit=20&offset=0`
+
+```json
+{
+  "items": [
+    { "entry_id": "a0000000-...", "title": "Mission Statement", "reads": 17 }
+  ],
+  "limit": 20,
+  "offset": 0,
+  "since": "24h"
+}
+```
+
+### `GET /analytics/top-endpoints?since=24h&limit=20&offset=0`
+
+```json
+{
+  "items": [
+    {
+      "endpoint": "/entries",
+      "count": 27,
+      "avg_duration_ms": 16.0,
+      "p95_duration_ms": 34.0
+    }
+  ],
+  "limit": 20,
+  "offset": 0,
+  "since": "24h"
+}
+```
+
+p95 is computed via `percentile_cont(0.95) WITHIN GROUP (ORDER BY duration_ms)`.
+
+### `GET /analytics/session-depth?actor_id=usr_admin&since=24h`
+
+```json
+{
+  "actor_id": "usr_admin",
+  "since": "24h",
+  "windows": [
+    { "window_start": "2026-04-16T17:45:00Z", "requests": 18, "entries_touched": 4, "duration_s": 246 }
+  ]
+}
+```
+
+Bucketing is 15-minute windows (`date_trunc('minute', ts) - (EXTRACT(MINUTE FROM ts)::int % 15) * interval '1 minute'`). `request_log` and `entry_access_log` are joined with `FULL OUTER JOIN` so a window shows up even if it has only requests or only entry reads.
+
+## MCP tool
+
+`get_usage_stats` wraps the three rollup endpoints for Claude Co-work / Claude Code.
+
+```
+get_usage_stats(
+  kind: "top-entries" | "top-endpoints" | "session-depth" | "summary" = "top-entries",
+  since: "1h" | "24h" | "7d" | "30d" = "24h",
+  actor_type: str | None = None,   # for top-entries
+  actor_id: str | None = None,     # required for session-depth
+  limit: int = 20,
+)
+```
+
+- `kind="summary"` fans out all three rollup calls concurrently (`asyncio.gather`) and returns `{"top_entries": ..., "top_endpoints": ..., "session_depth": ...}`.
+- Non-admin callers receive `{"error": "admin-only", "detail": ...}` — never a raised exception, never a 500.
+- Full reference: `skill/references/api-reference.md`.
+
+## Overhead
+
+The middleware targets **<2ms p95** under load. The insert runs in an `asyncio.create_task` so it does not block the response. The background coroutine opens a fresh pooled connection, executes `SET LOCAL ROLE kb_admin; SET LOCAL app.org_id = '...'; INSERT ...;` in one short transaction, and exits.
+
+Formal load measurements are owed to the concurrency harness in a follow-up; the smoke-test numbers on a local MacBook (9–27 ms end-to-end request latency for `/entries` with logging on) left plenty of headroom.
+
+## Test coverage
+
+`tests/test_observability.py` ships 11 integration cases covering: middleware behavior, `/health` exclusion, single vs. batched inserts, graph cache interaction, viewer 403 on analytics, rollup response shapes, `since` parser, `actor_type` validation, and RLS enforcement at the psql layer. Runs against the live stack (`BASE_URL`, `DB_DSN` env-overridable).

--- a/mcp/tools.py
+++ b/mcp/tools.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from mcp.server.fastmcp import FastMCP
 
 from client import CortexClient
@@ -471,3 +473,103 @@ def register_tools(mcp: FastMCP, api: CortexClient) -> None:
         to roll back. Cannot roll back an already rolled-back batch (returns 409).
         """
         return await api.delete(f"/import/{batch_id}")
+
+    # -------------------------------------------------------------------
+    # Analytics tools (admin-only)
+    # -------------------------------------------------------------------
+
+    def _coerce_admin_error(result: dict) -> dict:
+        """Convert a raw 403 CortexClient error dict into the documented shape.
+
+        CortexClient returns {"error": True, "status": 403, "detail": ...} on
+        HTTP 4xx/5xx. For admin-only endpoints we surface a friendlier
+        {"error": "admin-only", "detail": ...} so non-admin callers never see
+        a raw exception or a generic error envelope.
+        """
+        if isinstance(result, dict) and result.get("error") is True and result.get("status") == 403:
+            return {"error": "admin-only", "detail": result.get("detail")}
+        return result
+
+    @mcp.tool()
+    async def get_usage_stats(
+        kind: str = "top-entries",
+        since: str = "24h",
+        actor_type: str | None = None,
+        actor_id: str | None = None,
+        limit: int = 20,
+    ) -> dict:
+        """Usage analytics rollups for admins.
+
+        Wraps the /analytics/* endpoints and returns consolidated JSON for the
+        calling admin's org. Non-admin callers receive
+        {"error": "admin-only", "detail": ...} — never a raised exception and
+        never a raw 500.
+
+        kind:
+          - "top-entries"     — most-read entries in the window
+          - "top-endpoints"   — most-hit endpoints with latency stats
+          - "session-depth"   — session breakdown for a specific actor_id
+          - "summary"         — returns all three at once (single response)
+
+        since: "1h" | "24h" | "7d" | "30d" (default "24h")
+
+        actor_type: optional filter for top-entries — "user" | "agent" | "api".
+        actor_id: required for "session-depth" (and "summary" when you want
+          per-actor session data — omit to skip).
+        limit: page size for top-entries and top-endpoints (default 20).
+
+        Admin-only — non-admin callers get {"error": "admin-only", ...}.
+        """
+        if kind == "top-entries":
+            params: dict = {"since": since, "limit": limit}
+            if actor_type is not None:
+                params["actor_type"] = actor_type
+            return _coerce_admin_error(await api.get("/analytics/top-entries", params=params))
+
+        if kind == "top-endpoints":
+            params = {"since": since, "limit": limit}
+            return _coerce_admin_error(await api.get("/analytics/top-endpoints", params=params))
+
+        if kind == "session-depth":
+            params = {"since": since}
+            if actor_id is not None:
+                params["actor_id"] = actor_id
+            return _coerce_admin_error(await api.get("/analytics/session-depth", params=params))
+
+        if kind == "summary":
+            top_entries_params: dict = {"since": since, "limit": limit}
+            if actor_type is not None:
+                top_entries_params["actor_type"] = actor_type
+            top_endpoints_params: dict = {"since": since, "limit": limit}
+            session_depth_params: dict = {"since": since}
+            if actor_id is not None:
+                session_depth_params["actor_id"] = actor_id
+
+            top_entries, top_endpoints, session_depth = await asyncio.gather(
+                api.get("/analytics/top-entries", params=top_entries_params),
+                api.get("/analytics/top-endpoints", params=top_endpoints_params),
+                api.get("/analytics/session-depth", params=session_depth_params),
+            )
+
+            # If any sub-call returned 403 (admin-only), surface the same
+            # admin-only envelope so the whole summary call fails clearly
+            # rather than returning a half-populated dict.
+            for sub in (top_entries, top_endpoints, session_depth):
+                if (
+                    isinstance(sub, dict)
+                    and sub.get("error") is True
+                    and sub.get("status") == 403
+                ):
+                    return {"error": "admin-only", "detail": sub.get("detail")}
+
+            return {
+                "top_entries": top_entries,
+                "top_endpoints": top_endpoints,
+                "session_depth": session_depth,
+            }
+
+        return {
+            "error": "invalid-kind",
+            "detail": f"unknown kind {kind!r} — expected one of: "
+                      "top-entries, top-endpoints, session-depth, summary",
+        }

--- a/skill/references/api-reference.md
+++ b/skill/references/api-reference.md
@@ -1265,3 +1265,46 @@ The response's `content` field is now rendered, not raw:
 - Frontmatter (`---\n…\n---` block, with or without a surrounding ```` ```yaml ```` fence) is stripped.
 - `[[wiki-links]]` are resolved to markdown links of the form `[Label](/kb/<uuid>)`. Unresolved wiki-links pass through literally.
 - The unrendered body is still available via the raw version endpoints; routine reads should use the rendered form.
+
+---
+
+## MCP Tools — Analytics
+
+### get_usage_stats
+
+Usage analytics rollups for admins. Wraps the three `GET /analytics/*` endpoints (added in spec 0034c) into a single MCP tool.
+
+**Admin-only.** Non-admin callers receive a structured dict `{"error": "admin-only", "detail": ...}` — never a raised exception and never a raw 500.
+
+**Parameters:**
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `kind` | string | `"top-entries"` | One of: `top-entries`, `top-endpoints`, `session-depth`, `summary` |
+| `since` | string | `"24h"` | Window size. One of: `1h`, `24h`, `7d`, `30d` |
+| `actor_type` | string | null | Optional filter for `top-entries`: `user`, `agent`, or `api` |
+| `actor_id` | string | null | Required for `session-depth` to scope the breakdown to a single actor |
+| `limit` | int | 20 | Page size for `top-entries` and `top-endpoints` |
+
+**Kinds:**
+
+- **`top-entries`** — Proxies `GET /analytics/top-entries`. Returns `{ "items": [{"entry_id", "title", "reads"}], "limit", "offset", "since" }`.
+- **`top-endpoints`** — Proxies `GET /analytics/top-endpoints`. Returns `{ "items": [{"endpoint", "count", "avg_duration_ms", "p95_duration_ms"}], "limit", "offset", "since" }`.
+- **`session-depth`** — Proxies `GET /analytics/session-depth`. Returns `{ "actor_id", "windows": [{"window_start", "requests", "entries_touched", "duration_s"}], "since" }`.
+- **`summary`** — Fans out all three calls concurrently via `asyncio.gather` and returns `{ "top_entries": {...}, "top_endpoints": {...}, "session_depth": {...} }`. If any sub-call returns 403, the whole envelope collapses to `{"error": "admin-only", ...}`.
+
+**Error contract:**
+
+| Caller | Response |
+|---|---|
+| Admin | Rollup JSON as documented per kind |
+| Non-admin (viewer/editor/commenter/agent) | `{"error": "admin-only", "detail": ...}` |
+| Unknown `kind` value | `{"error": "invalid-kind", "detail": "unknown kind ..."}` |
+
+**Example — summary for the last week:**
+
+```python
+await get_usage_stats(kind="summary", since="7d", limit=10)
+```
+
+Returns the same structured envelope as three separate calls, in one round-trip.

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,481 @@
+"""Integration tests for the observability stack (spec 0034c, T-0193).
+
+Exercises the full observability pipeline against a live API:
+- request_log middleware (logs every non-health request with duration/status).
+- entry_access_log tracking on read paths (single batched INSERT per request).
+- Admin analytics rollup endpoints (/analytics/top-entries, top-endpoints).
+- RLS denial on log tables for non-admin roles.
+
+Prerequisites:
+  1. Observability worktree stack up:
+       COMPOSE_PROJECT_NAME=brilliant-obs docker compose up -d
+     (API on :8030, Postgres on :5462)
+  2. pip install -r tests/requirements-dev.txt
+
+Run:
+  pytest tests/test_observability.py -v
+
+Env overrides (keep tests runnable from either worktree after merge):
+  CORTEX_BASE_URL  -- default http://localhost:8030
+  CORTEX_DB_DSN    -- default postgresql://postgres:dev@localhost:5462/cortex
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+
+import pytest
+import requests
+
+try:
+    import psycopg
+    _PSYCOPG_AVAILABLE = True
+except ImportError:
+    _PSYCOPG_AVAILABLE = False
+
+
+# The observability worktree runs on 8030/:5462; the primary tree runs on
+# 8010/:5442. Default to the observability ports so this file works without
+# env overrides when executed from this worktree, but allow override so the
+# same tests can run from the primary tree after merge.
+BASE_URL = os.environ.get("CORTEX_BASE_URL", "http://localhost:8030")
+DB_DSN = os.environ.get(
+    "CORTEX_DB_DSN",
+    "postgresql://postgres:dev@localhost:5462/cortex",
+)
+
+ADMIN_KEY = "bkai_adm1_testkey_admin"
+EDITOR_KEY = "bkai_edit_testkey_editor"
+VIEWER_KEY = "bkai_view_testkey_viewer"
+AGENT_KEY = "bkai_agnt_testkey_agent"
+
+ORG_ID = "org_demo"
+ADMIN_USER_ID = "usr_admin"
+
+REQUEST_TIMEOUT = 10.0
+
+# Seeded entries (see db/migrations/005_seed.sql). Use a stable, known id
+# so we don't have to create+teardown an entry just to read one.
+SEED_ENTRY_ID = "a0000000-0000-0000-0000-000000000001"
+
+# Async background inserts should land well under 2s; polling bounds the
+# wait so a failing test fails fast rather than stalling the suite.
+_MAX_POLL_SECONDS = 3.0
+_POLL_INTERVAL = 0.1
+
+
+def _headers(key: str) -> dict:
+    return {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
+
+
+def _api_available() -> bool:
+    try:
+        return requests.get(f"{BASE_URL}/health", timeout=2.0).status_code == 200
+    except Exception:
+        return False
+
+
+def _db_available() -> bool:
+    if not _PSYCOPG_AVAILABLE:
+        return False
+    try:
+        with psycopg.connect(DB_DSN, connect_timeout=2) as _:
+            return True
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _api_available(),
+        reason=f"Brilliant API not reachable at {BASE_URL} (start `docker compose up -d`).",
+    ),
+    pytest.mark.skipif(
+        not _PSYCOPG_AVAILABLE,
+        reason="psycopg not installed; cannot verify observability rows",
+    ),
+    pytest.mark.skipif(
+        not _db_available(),
+        reason=f"Postgres not reachable at {DB_DSN}",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+def _admin_cursor(conn):
+    """Configure an RLS-scoped cursor that sees the admin's view of the logs.
+
+    Raw postgres connections run under FORCE RLS — without role+org_id set,
+    SELECTs return 0 rows regardless of actual content. Mirror what the API
+    does for admin-scoped reads.
+    """
+    cur = conn.cursor()
+    cur.execute("SET ROLE kb_admin")
+    cur.execute(f"SET app.org_id = '{ORG_ID}'")
+    return cur
+
+
+def _truncate_logs() -> bool:
+    """TRUNCATE both log tables as the postgres superuser.
+
+    kb_admin only has SELECT/INSERT, so TRUNCATE requires superuser. We gate
+    row-counting tests on this succeeding (if the DSN isn't superuser, those
+    tests skip rather than produce nondeterministic counts).
+    """
+    try:
+        with psycopg.connect(DB_DSN, autocommit=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute("TRUNCATE entry_access_log, request_log")
+        return True
+    except Exception:
+        return False
+
+
+def _can_truncate() -> bool:
+    # Used as a skip gate; don't actually wipe anything here.
+    try:
+        with psycopg.connect(DB_DSN, autocommit=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT has_table_privilege(current_user, 'entry_access_log', 'TRUNCATE')")
+                return bool(cur.fetchone()[0])
+    except Exception:
+        return False
+
+
+def _wait_for(predicate, max_seconds: float = _MAX_POLL_SECONDS):
+    """Poll `predicate()` until it returns truthy. Returns last value."""
+    deadline = time.time() + max_seconds
+    value = predicate()
+    while not value and time.time() < deadline:
+        time.sleep(_POLL_INTERVAL)
+        value = predicate()
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_middleware_records_read():
+    """GET /entries should land exactly one row in request_log with the
+    matched path template, 200 status, and a non-negative duration.
+    """
+    if not _truncate_logs():
+        pytest.skip("DB user lacks TRUNCATE on log tables; cannot isolate counts.")
+
+    r = requests.get(
+        f"{BASE_URL}/entries?limit=1",
+        headers=_headers(ADMIN_KEY),
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r.status_code == 200, r.text
+
+    def _look():
+        with psycopg.connect(DB_DSN, autocommit=True) as conn:
+            cur = _admin_cursor(conn)
+            cur.execute(
+                """
+                SELECT endpoint, status, duration_ms
+                FROM request_log
+                WHERE endpoint = '/entries'
+                ORDER BY ts DESC
+                LIMIT 1
+                """
+            )
+            return cur.fetchone()
+
+    row = _wait_for(_look)
+    assert row is not None, "middleware did not record a row for GET /entries"
+    endpoint, status, duration_ms = row
+    assert endpoint == "/entries"
+    assert status == 200
+    # duration_ms is rounded to int so a sub-millisecond response can legitimately
+    # be 0. Require >= 0 rather than > 0 to avoid flakes on fast hardware.
+    assert duration_ms is not None and duration_ms >= 0
+
+
+def test_health_not_logged():
+    """/health is skipped by the middleware — hit it 5 times, expect 0 rows."""
+    if not _truncate_logs():
+        pytest.skip("DB user lacks TRUNCATE on log tables; cannot isolate counts.")
+
+    for _ in range(5):
+        r = requests.get(f"{BASE_URL}/health", timeout=REQUEST_TIMEOUT)
+        assert r.status_code == 200
+
+    # Give any stray async tasks a moment to flush before asserting absence.
+    time.sleep(0.5)
+
+    with psycopg.connect(DB_DSN, autocommit=True) as conn:
+        cur = _admin_cursor(conn)
+        cur.execute("SELECT COUNT(*) FROM request_log WHERE endpoint = '/health'")
+        assert cur.fetchone()[0] == 0
+
+
+def test_entry_get_writes_one_access_row():
+    """GET /entries/{id} should write exactly 1 row to entry_access_log."""
+    if not _truncate_logs():
+        pytest.skip("DB user lacks TRUNCATE on log tables; cannot isolate counts.")
+
+    r = requests.get(
+        f"{BASE_URL}/entries/{SEED_ENTRY_ID}",
+        headers=_headers(ADMIN_KEY),
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r.status_code == 200, r.text
+
+    def _look():
+        with psycopg.connect(DB_DSN, autocommit=True) as conn:
+            cur = _admin_cursor(conn)
+            cur.execute(
+                "SELECT COUNT(*) FROM entry_access_log WHERE entry_id = %s",
+                (SEED_ENTRY_ID,),
+            )
+            return cur.fetchone()[0]
+
+    count = _wait_for(lambda: _look() or None) or 0
+    assert count == 1, f"expected 1 access_log row, got {count}"
+
+
+def test_entries_list_batched_insert():
+    """GET /entries?limit=5 writes 5 rows that share a single `ts` (proxy for
+    single-statement INSERT — all rows get the same statement_timestamp)."""
+    if not _truncate_logs():
+        pytest.skip("DB user lacks TRUNCATE on log tables; cannot isolate counts.")
+
+    r = requests.get(
+        f"{BASE_URL}/entries?limit=5",
+        headers=_headers(ADMIN_KEY),
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r.status_code == 200, r.text
+    returned = len(r.json()["entries"])
+    assert returned == 5, f"expected 5 entries from seed data, got {returned}"
+
+    def _look():
+        with psycopg.connect(DB_DSN, autocommit=True) as conn:
+            cur = _admin_cursor(conn)
+            cur.execute("SELECT COUNT(*), COUNT(DISTINCT ts) FROM entry_access_log")
+            total, distinct_ts = cur.fetchone()
+            return (total, distinct_ts) if total >= 5 else None
+
+    result = _wait_for(_look)
+    assert result is not None, "entry_access_log never reached 5 rows"
+    total, distinct_ts = result
+    assert total == 5, f"expected exactly 5 access rows, got {total}"
+    assert distinct_ts == 1, (
+        f"batched insert should share one ts across all rows, got {distinct_ts}"
+    )
+
+
+def test_graph_batched_insert():
+    """/graph?scope=org&limit_nodes=N writes exactly N rows to entry_access_log.
+
+    The /graph response is cached 45s keyed by (org, user, scope, path,
+    include_archived, limit_nodes). A cached hit short-circuits before the
+    access-log INSERT. Pick a `limit_nodes` value derived from the current
+    wall clock so back-to-back runs of this test always miss the cache.
+    """
+    if not _truncate_logs():
+        pytest.skip("DB user lacks TRUNCATE on log tables; cannot isolate counts.")
+
+    # Wall-clock-seeded limit_nodes (in [3, 30]) avoids cache collision on rerun.
+    unique_limit = (int(time.time()) % 28) + 3
+
+    r = requests.get(
+        f"{BASE_URL}/graph?scope=org&limit_nodes={unique_limit}",
+        headers=_headers(ADMIN_KEY),
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r.status_code == 200, r.text
+    nodes = r.json()["nodes"]
+    n = len(nodes)
+    assert n > 0, "graph returned no nodes — cannot verify batched insert"
+
+    def _look():
+        with psycopg.connect(DB_DSN, autocommit=True) as conn:
+            cur = _admin_cursor(conn)
+            cur.execute("SELECT COUNT(*) FROM entry_access_log")
+            total = cur.fetchone()[0]
+            return total if total >= n else None
+
+    total = _wait_for(_look)
+    assert total is not None, f"entry_access_log never reached {n} rows"
+    assert total == n, f"expected {n} rows (one per returned node), got {total}"
+
+
+def test_viewer_denied_on_analytics():
+    """Viewer key gets 403 on every analytics endpoint (admin-only gate)."""
+    r = requests.get(
+        f"{BASE_URL}/analytics/top-entries?since=24h",
+        headers=_headers(VIEWER_KEY),
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r.status_code == 403, f"expected 403 for viewer, got {r.status_code}: {r.text}"
+
+    # Sanity-check the other two rollups too so a missing gate anywhere
+    # gets caught by this test.
+    r2 = requests.get(
+        f"{BASE_URL}/analytics/top-endpoints?since=24h",
+        headers=_headers(VIEWER_KEY),
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r2.status_code == 403
+
+    r3 = requests.get(
+        f"{BASE_URL}/analytics/session-depth?actor_id={ADMIN_USER_ID}&since=24h",
+        headers=_headers(VIEWER_KEY),
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r3.status_code == 403
+
+
+def test_admin_top_entries_shape():
+    """Admin GET /analytics/top-entries returns the stable rollup shape.
+
+    Downstream MCP tool (T-0192) depends on these exact keys.
+    """
+    r = requests.get(
+        f"{BASE_URL}/analytics/top-entries?since=24h&limit=5",
+        headers=_headers(ADMIN_KEY),
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    # Top-level shape contract.
+    assert set(body.keys()) >= {"items", "limit", "offset", "since"}, body.keys()
+    assert body["limit"] == 5
+    assert body["offset"] == 0
+    assert body["since"] == "24h"
+    assert isinstance(body["items"], list)
+
+    # If any items are present, they must have (entry_id, title, reads).
+    for item in body["items"]:
+        assert set(item.keys()) >= {"entry_id", "title", "reads"}, item
+        assert isinstance(item["reads"], int)
+
+
+def test_admin_top_endpoints_p95():
+    """Admin GET /analytics/top-endpoints returns numeric avg + p95 duration.
+
+    Seed an entry into the request log (via at least one logged request) so
+    the rollup has something to report.
+    """
+    # Ensure there's at least one logged request in the window.
+    requests.get(
+        f"{BASE_URL}/entries?limit=1",
+        headers=_headers(ADMIN_KEY),
+        timeout=REQUEST_TIMEOUT,
+    )
+    # Give the fire-and-forget insert time to land before reading.
+    time.sleep(0.3)
+
+    r = requests.get(
+        f"{BASE_URL}/analytics/top-endpoints?since=24h&limit=5",
+        headers=_headers(ADMIN_KEY),
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    assert set(body.keys()) >= {"items", "limit", "offset", "since"}
+    assert body["limit"] == 5
+    assert isinstance(body["items"], list)
+    assert len(body["items"]) >= 1, "expected at least one endpoint in rollup"
+
+    for item in body["items"]:
+        assert set(item.keys()) >= {
+            "endpoint",
+            "count",
+            "avg_duration_ms",
+            "p95_duration_ms",
+        }, item
+        assert isinstance(item["count"], int) and item["count"] > 0
+        # Both duration fields should be numeric (float) when count > 0.
+        assert isinstance(item["avg_duration_ms"], (int, float)), item
+        assert isinstance(item["p95_duration_ms"], (int, float)), item
+        assert item["avg_duration_ms"] >= 0
+        assert item["p95_duration_ms"] >= 0
+
+
+def test_since_parser_rejects_bogus():
+    """?since=bogus returns 422 across all analytics endpoints."""
+    r = requests.get(
+        f"{BASE_URL}/analytics/top-entries?since=bogus",
+        headers=_headers(ADMIN_KEY),
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r.status_code == 422, f"expected 422, got {r.status_code}: {r.text}"
+
+    r2 = requests.get(
+        f"{BASE_URL}/analytics/top-endpoints?since=forever",
+        headers=_headers(ADMIN_KEY),
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r2.status_code == 422
+
+
+def test_rls_viewer_cannot_read_access_log():
+    """Direct psycopg connection as kb_viewer sees 0 rows from log tables
+    even when admin sees non-zero. Verifies FORCE RLS + admin-only SELECT
+    policy are both in effect.
+    """
+    # Generate a guaranteed row before we check.
+    requests.get(
+        f"{BASE_URL}/entries/{SEED_ENTRY_ID}",
+        headers=_headers(ADMIN_KEY),
+        timeout=REQUEST_TIMEOUT,
+    )
+    # Let the access-log INSERT land.
+    time.sleep(0.3)
+
+    with psycopg.connect(DB_DSN, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            # Admin perspective: should see rows.
+            cur.execute("SET ROLE kb_admin")
+            cur.execute(f"SET app.org_id = '{ORG_ID}'")
+            cur.execute("SELECT COUNT(*) FROM entry_access_log")
+            admin_seen = cur.fetchone()[0]
+            cur.execute("SELECT COUNT(*) FROM request_log")
+            admin_seen_req = cur.fetchone()[0]
+
+            assert admin_seen > 0, (
+                "admin sees 0 access-log rows; cannot test viewer denial "
+                "(the test expects recent activity to exist)."
+            )
+
+            # Swap to viewer. RESET ROLE first because SET ROLE is cumulative
+            # in the same session.
+            cur.execute("RESET ROLE")
+            cur.execute("SET ROLE kb_viewer")
+            cur.execute(f"SET app.org_id = '{ORG_ID}'")
+
+            cur.execute("SELECT COUNT(*) FROM entry_access_log")
+            viewer_seen = cur.fetchone()[0]
+            cur.execute("SELECT COUNT(*) FROM request_log")
+            viewer_seen_req = cur.fetchone()[0]
+
+    assert viewer_seen == 0, (
+        f"viewer should see 0 entry_access_log rows under FORCE RLS, "
+        f"saw {viewer_seen} (admin saw {admin_seen})."
+    )
+    assert viewer_seen_req == 0, (
+        f"viewer should see 0 request_log rows, saw {viewer_seen_req} "
+        f"(admin saw {admin_seen_req})."
+    )
+
+
+def test_actor_type_filter_rejects_bogus():
+    """?actor_type=bogus returns 422 (not 500, not silent empty)."""
+    r = requests.get(
+        f"{BASE_URL}/analytics/top-entries?since=24h&actor_type=martian",
+        headers=_headers(ADMIN_KEY),
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r.status_code == 422, f"expected 422, got {r.status_code}: {r.text}"

--- a/tests/validate_schema.sql
+++ b/tests/validate_schema.sql
@@ -235,4 +235,85 @@ BEGIN
 END;
 $$;
 
+-- =============================================================================
+-- TEST 7: Observability tables — admin can read, viewer sees zero
+-- =============================================================================
+
+DO $$
+DECLARE
+    admin_visible INTEGER;
+    viewer_visible INTEGER;
+BEGIN
+    -- Admin seeds a row
+    SET LOCAL ROLE kb_admin;
+    SET LOCAL app.user_id = 'usr_admin';
+    SET LOCAL app.org_id = 'org_demo';
+    SET LOCAL app.role = 'admin';
+    SET LOCAL app.department = 'leadership';
+
+    INSERT INTO entry_access_log (org_id, actor_type, actor_id, entry_id, source)
+    VALUES ('org_demo', 'user', 'usr_admin',
+            'a0000000-0000-0000-0000-000000000001', 'web_ui');
+
+    SELECT count(*) INTO admin_visible FROM entry_access_log;
+    RESET ROLE;
+
+    -- Viewer must see 0 rows (no SELECT policy for non-admin)
+    SET LOCAL ROLE kb_viewer;
+    SET LOCAL app.user_id = 'usr_viewer';
+    SET LOCAL app.org_id = 'org_demo';
+    SET LOCAL app.role = 'viewer';
+    SET LOCAL app.department = '';
+
+    SELECT count(*) INTO viewer_visible FROM entry_access_log;
+    RESET ROLE;
+
+    IF admin_visible >= 1 AND viewer_visible = 0 THEN
+        RAISE NOTICE 'PASS: entry_access_log RLS — admin sees %, viewer sees %', admin_visible, viewer_visible;
+    ELSE
+        RAISE NOTICE 'FAIL: entry_access_log RLS — admin sees %, viewer sees % (expected admin>=1, viewer=0)', admin_visible, viewer_visible;
+    END IF;
+
+    -- Clean up (as table owner — tables are append-only for kb roles)
+    DELETE FROM entry_access_log WHERE actor_id = 'usr_admin';
+END;
+$$;
+
+DO $$
+DECLARE
+    admin_visible INTEGER;
+    viewer_visible INTEGER;
+BEGIN
+    SET LOCAL ROLE kb_admin;
+    SET LOCAL app.user_id = 'usr_admin';
+    SET LOCAL app.org_id = 'org_demo';
+    SET LOCAL app.role = 'admin';
+    SET LOCAL app.department = 'leadership';
+
+    INSERT INTO request_log (org_id, actor_id, endpoint, method, status,
+                              response_bytes, approx_tokens, duration_ms)
+    VALUES ('org_demo', 'usr_admin', '/entries', 'GET', 200, 1024, 256, 12);
+
+    SELECT count(*) INTO admin_visible FROM request_log;
+    RESET ROLE;
+
+    SET LOCAL ROLE kb_viewer;
+    SET LOCAL app.user_id = 'usr_viewer';
+    SET LOCAL app.org_id = 'org_demo';
+    SET LOCAL app.role = 'viewer';
+    SET LOCAL app.department = '';
+
+    SELECT count(*) INTO viewer_visible FROM request_log;
+    RESET ROLE;
+
+    IF admin_visible >= 1 AND viewer_visible = 0 THEN
+        RAISE NOTICE 'PASS: request_log RLS — admin sees %, viewer sees %', admin_visible, viewer_visible;
+    ELSE
+        RAISE NOTICE 'FAIL: request_log RLS — admin sees %, viewer sees % (expected admin>=1, viewer=0)', admin_visible, viewer_visible;
+    END IF;
+
+    DELETE FROM request_log WHERE actor_id = 'usr_admin';
+END;
+$$;
+
 DO $$ BEGIN RAISE NOTICE '--- All validation tests complete ---'; END; $$;


### PR DESCRIPTION
Closes #15.

## Summary

Admin-only observability subsystem so teams can answer *what entries are agents reading most this week?* and surface latency hotspots via the API and MCP.

- New tables (migration 023): `entry_access_log` (one row per entry surfaced) and `request_log` (one row per HTTP request; `/health` + `/static` skipped). Append-only, admin-only SELECT via RLS.
- Fire-and-forget request-log middleware — path-template logged (not raw IDs), truncated to 256 chars, `approx_tokens = bytes // 4`. Logging failures are swallowed.
- Per-entry read tracking on `entries`, `graph`, `links`, `staging` read paths — one batched INSERT per request.
- Admin rollup endpoints:
  - `GET /analytics/top-entries` (actor_type, since)
  - `GET /analytics/top-endpoints` (since; p95 via `percentile_cont(0.95)`)
  - `GET /analytics/session-depth` (actor_id, since; 15-min buckets via FULL OUTER JOIN).
  Non-admin callers get `403` before the DB is touched. `since` accepts `1h / 24h / 7d / 30d`.
- MCP tool `get_usage_stats(kind, since, actor_type, actor_id, limit)` with `kind="summary"` fan-out via `asyncio.gather`. API `403` is coerced to `{"error": "admin-only", ...}` so non-admins never see a 500.
- Docs: `docs/OBSERVABILITY.md` covers tables, RLS, PII posture (actor_id logged; IPs and bodies are not), 90-day retention guidance, rollup shapes, and the MCP tool. README Features table links to it.

## Privacy posture

Logged: `actor_id` (user ID, not email), `org_id`, path template, status, duration, response size, `approx_tokens`.
Not logged: IP addresses, request/response bodies, email addresses.

## Test plan

- [x] `pytest tests/test_observability.py -v` → 11 passed
- [x] `pytest tests/ -q` → 46 passed
- [x] `tests/validate_schema.sql` → 8/8 (includes two new RLS probes confirming viewer sees 0 rows while admin sees full set)
- [x] Manual admin probe: `curl "/analytics/top-entries?since=24h"` returns shaped JSON
- [x] Non-admin matrix (viewer / editor / agent × 3 endpoints) → 9/9 return 403
- [x] `/health` exclusion verified — 0 rows after repeated hits
- [x] `/entries?limit=5` produces 5 rows sharing one `ts` (single-statement INSERT)

## Known follow-ups (not blockers)

- **Middleware load-test** for the spec's <2ms p95 overhead target is still owed. Smoke runs show single-digit-ms added; formal harness pass deferred.
- **Graph 45s cache** suppresses duplicate access-log writes on cache hits. Intentional (don't inflate read counts on cache serves) but worth documenting for downstream analytics consumers.
- **Retention knob** (90-day default) is documented in `OBSERVABILITY.md` but not yet enforced — operator-run `DELETE` for now.
- **Per-tenant privacy flag** on `organizations.settings` to opt out of `actor_id` capture — mentioned in docs, not implemented.