### PR TITLE
feat: file attachments with PDF digest pipeline (#17)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -39,3 +39,20 @@ ADMIN_PASSWORD=change-me-before-first-run
 # If unset, Tier 3 staging items escalate to human review (the default).
 # If set, Tier 3 items get an Anthropic API review before promotion.
 # ANTHROPIC_API_KEY=
+
+# --- Blob storage (attachments) ---
+# Backend for attachment blobs. `local` writes to the filesystem at
+# LOCAL_STORAGE_ROOT (default /data/uploads). `s3` uses any
+# S3-compatible service (AWS, Cloudflare R2, MinIO).
+STORAGE_BACKEND=local
+LOCAL_STORAGE_ROOT=/data/uploads
+# Optional HMAC key for signing local-backend download URLs. If unset, a
+# random 32-byte key is generated and persisted to
+# {LOCAL_STORAGE_ROOT}/.signing_key on first use.
+# LOCAL_STORAGE_SIGNING_KEY=
+# For STORAGE_BACKEND=s3:
+# S3_ENDPOINT_URL=
+# S3_BUCKET=
+# S3_ACCESS_KEY=
+# S3_SECRET_KEY=
+# S3_REGION=auto

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Brilliant ships with an MCP server (`mcp/`) and a Claude skill (`skill/`) for Cl
 | Row-level security (multi-tenant) | Shipped, single-org validated |
 | MCP integration (Claude Co-work / Claude Code) | Shipped |
 | Obsidian vault import | Shipped |
+| File attachments (PDF digest, S3-compatible storage, dedup by content hash) | Shipped — see [docs/ATTACHMENTS.md](docs/ATTACHMENTS.md) |
 | Tier 3 AI reviewer (Anthropic) | Shipped, opt-in via ANTHROPIC_API_KEY |
 | KB-native review escalation | Shipped |
 | Concurrent writer stress test | 20–120 clients, ~178 ops/sec, 99.8%+ success, 0 data corruption (see below) |

--- a/api/main.py
+++ b/api/main.py
@@ -61,6 +61,7 @@ _route_modules = [
     ("routes.groups", "groups_router", "/groups"),
     ("routes.comments", "entries_comments_router", "/entries"),
     ("routes.comments", "comments_router", "/comments"),
+    ("routes.attachments", "router", "/attachments"),
 ]
 
 for module_path, attr_name, prefix in _route_modules:

--- a/api/models.py
+++ b/api/models.py
@@ -573,3 +573,35 @@ class CommentResponse(BaseModel):
     created_at: datetime
     resolved_at: datetime | None
     resolved_by: str | None
+
+
+# =============================================================================
+# Attachment models (spec 0034b — file uploads / PDF digest)
+# =============================================================================
+
+
+VALID_ATTACHMENT_ROLES = {"source", "derived", "thumbnail"}
+
+
+class BlobResponse(BaseModel):
+    """Content-addressed blob metadata. Storage backend + key are intentionally
+    omitted from the public API response — consumers use signed URLs via the
+    GET /attachments/{blob_id} endpoint to retrieve bytes.
+    """
+
+    id: str
+    sha256: str
+    content_type: str
+    size_bytes: int
+    uploaded_at: datetime
+
+
+class AttachmentResponse(BaseModel):
+    """An entry_attachments row plus the embedded blob record."""
+
+    id: str
+    entry_id: str
+    blob_id: str
+    role: str  # source | derived | thumbnail
+    created_at: datetime
+    blob: BlobResponse | None = None

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,3 +4,6 @@ psycopg[binary]>=3.2,<4.0
 psycopg_pool>=3.2,<4.0
 bcrypt>=4.0,<5.0
 anthropic>=0.40.0
+boto3>=1.34,<2.0
+python-multipart>=0.0.9,<1.0
+pypdf>=4.0,<5.0

--- a/api/routes/attachments.py
+++ b/api/routes/attachments.py
@@ -1,0 +1,471 @@
+"""Attachment upload endpoint (spec 0034b, T-0182 / T-0183 / T-0184).
+
+`POST /attachments` accepts a multipart file upload, content-addresses it
+by sha256, dedupes per-org against the `blobs` table, and persists bytes
+through the configured `Storage` backend (local FS or S3-compatible).
+
+Auth: any authenticated user. Blob inserts run under the caller's
+Postgres role via `get_db(user)`, so RLS (migration 022) enforces
+`org_id = app.org_id AND uploaded_by = app.user_id`.
+
+Dedup semantics:
+  - Same bytes, same org → single `blobs` row; second call returns
+    `dedup: true` with the original `blob_id`.
+  - Same bytes, different orgs → two distinct `blobs` rows
+    (tenant isolation holds even with a shared backend).
+
+When `digest=true` AND the effective content-type is `application/pdf`,
+T-0183 wires an extraction pass via `services.pdf_extract.extract_pdf`:
+a staging row with `submission_category='attachment_digest'` is created,
+the blob_id is stashed in `proposed_meta`, and for Tier 1/2 submissions
+the row is auto-promoted synchronously so the resulting entry already
+carries an `entry_attachments(role='source')` link on return.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import mimetypes
+import os
+import re
+
+from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile
+from fastapi.responses import RedirectResponse, Response
+from psycopg.rows import dict_row
+
+from auth import UserContext, get_current_user
+from database import get_db, get_pool
+from routes.staging import _assign_governance_tier, _promote_staging_item
+from services.pdf_extract import extract_pdf
+from services.storage import get_storage, verify_local_signed_url
+
+
+router = APIRouter(tags=["attachments"])
+
+
+# 50 MiB default cap; override via MAX_ATTACHMENT_BYTES env.
+_DEFAULT_MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024
+_READ_CHUNK = 65536
+
+
+def _max_attachment_bytes() -> int:
+    """Read the per-request size cap from env at call time.
+
+    Read on each request (rather than at import) so tests can tweak the
+    cap via monkeypatching the environment without re-importing the
+    module.
+    """
+    raw = os.environ.get("MAX_ATTACHMENT_BYTES")
+    if not raw:
+        return _DEFAULT_MAX_ATTACHMENT_BYTES
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_MAX_ATTACHMENT_BYTES
+    return value if value > 0 else _DEFAULT_MAX_ATTACHMENT_BYTES
+
+
+@router.post("", status_code=201)
+async def upload_attachment(
+    file: UploadFile = File(...),
+    digest: bool = Query(False, description="If true, run PDF digest pipeline (T-0183)"),
+    content_type: str | None = Query(
+        None,
+        description="Override the multipart content-type (e.g. when uploading from a tool that sends octet-stream).",
+    ),
+    user: UserContext = Depends(get_current_user),
+):
+    """Upload a file, dedupe by sha256 within org, return blob metadata.
+
+    Response shape:
+        {
+            "blob_id": "<uuid>",
+            "sha256": "<hex>",
+            "dedup": <bool>,
+            "size_bytes": <int>,
+            "content_type": "<mime>",
+            "staging_id": "<uuid>"    # only when digest=True and PDF
+        }
+    """
+    max_bytes = _max_attachment_bytes()
+
+    # Stream into memory, hashing as we go and counting bytes manually.
+    # UploadFile.size isn't populated until the file is fully read, so
+    # enforcement has to happen inline on the running byte counter.
+    hasher = hashlib.sha256()
+    buf = io.BytesIO()
+    total = 0
+    while True:
+        chunk = await file.read(_READ_CHUNK)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > max_bytes:
+            raise HTTPException(
+                status_code=413,
+                detail=f"Attachment exceeds MAX_ATTACHMENT_BYTES ({max_bytes} bytes)",
+            )
+        hasher.update(chunk)
+        buf.write(chunk)
+
+    sha256_hex = hasher.hexdigest()
+    data = buf.getvalue()
+
+    # Effective content type: explicit query override > multipart header
+    # > application/octet-stream fallback.
+    effective_ct = (
+        content_type
+        or file.content_type
+        or "application/octet-stream"
+    )
+
+    blob_id: str
+    dedup: bool
+    resp_size_bytes: int
+    resp_content_type: str
+
+    async with get_db(user) as conn:
+        # Dedup probe: has this org already uploaded these exact bytes?
+        cur = await conn.execute(
+            """
+            SELECT id, storage_backend, storage_key, content_type, size_bytes
+            FROM blobs
+            WHERE org_id = %s AND sha256 = %s
+            """,
+            (user.org_id, sha256_hex),
+        )
+        cur.row_factory = dict_row
+        existing = await cur.fetchone()
+
+        if existing is not None:
+            blob_id = str(existing["id"])
+            dedup = True
+            resp_size_bytes = int(existing["size_bytes"])
+            resp_content_type = existing["content_type"]
+        else:
+            # New blob: persist bytes to the backend first, then record the
+            # pointer row. If the INSERT fails (RLS, unique race), the bytes
+            # are still on-disk but orphaned — acceptable for v1; a sweep
+            # job can reconcile later.
+            storage = get_storage()
+            storage_key = await storage.put(
+                user.org_id, sha256_hex, effective_ct, data
+            )
+            storage_backend = (
+                os.environ.get("STORAGE_BACKEND") or "local"
+            ).strip().lower()
+
+            # Race-safe insert: if a concurrent request won the race, fall
+            # back to the existing row so both callers see consistent IDs.
+            cur = await conn.execute(
+                """
+                INSERT INTO blobs (
+                    org_id, sha256, content_type, size_bytes,
+                    storage_backend, storage_key, uploaded_by
+                ) VALUES (
+                    %s, %s, %s, %s, %s, %s, %s
+                )
+                ON CONFLICT (org_id, sha256) DO NOTHING
+                RETURNING id, content_type, size_bytes
+                """,
+                (
+                    user.org_id,
+                    sha256_hex,
+                    effective_ct,
+                    total,
+                    storage_backend,
+                    storage_key,
+                    user.id,
+                ),
+            )
+            cur.row_factory = dict_row
+            inserted = await cur.fetchone()
+
+            if inserted is None:
+                # Lost the race — another writer inserted between our probe
+                # and our INSERT. Re-read and return that row, flagging as
+                # dedup so the caller's idempotency expectation holds.
+                cur = await conn.execute(
+                    """
+                    SELECT id, content_type, size_bytes
+                    FROM blobs
+                    WHERE org_id = %s AND sha256 = %s
+                    """,
+                    (user.org_id, sha256_hex),
+                )
+                cur.row_factory = dict_row
+                inserted = await cur.fetchone()
+                if inserted is None:
+                    # Shouldn't happen — ON CONFLICT fired but SELECT empty.
+                    raise HTTPException(
+                        status_code=500,
+                        detail="Blob persisted but row not visible; retry.",
+                    )
+                blob_id = str(inserted["id"])
+                dedup = True
+                resp_size_bytes = int(inserted["size_bytes"])
+                resp_content_type = inserted["content_type"]
+            else:
+                blob_id = str(inserted["id"])
+                dedup = False
+                resp_size_bytes = int(inserted["size_bytes"])
+                resp_content_type = inserted["content_type"]
+
+        response: dict = {
+            "blob_id": blob_id,
+            "sha256": sha256_hex,
+            "dedup": dedup,
+            "size_bytes": resp_size_bytes,
+            "content_type": resp_content_type,
+        }
+
+        # --- PDF digest branch (T-0183) -----------------------------------
+        # When the caller asks to digest a PDF, extract text via pypdf and
+        # drop a staging row with submission_category='attachment_digest'.
+        # The staging row carries the blob_id in proposed_meta; the normal
+        # promotion path (routes/staging.py::_promote_staging_item) reads
+        # that meta after entry creation and inserts the entry_attachments
+        # join row so the blob is retrievable via the entry afterwards.
+        #
+        # Failure mode: if pypdf can't read the bytes, `extract_pdf`
+        # returns ("", "") and we still create a staging row — an empty
+        # digest is preferable to a 500 that hides the uploaded blob.
+        if digest and effective_ct == "application/pdf":
+            title, text = extract_pdf(data, filename=file.filename)
+
+            # Build a Tier-assigned staging row mirroring submit_staging's
+            # tier selection for agent/api sources (Tier 2 for agents on
+            # non-sensitive creates); mirroring the helper rather than
+            # hardcoding keeps the behavior aligned if the matrix evolves.
+            governance_tier = _assign_governance_tier(
+                change_type="create",
+                sensitivity=None,
+                source=user.source,
+                role=user.role,
+            )
+
+            # Sanitize title for the target_path segment: strip anything
+            # that isn't alnum/dash/underscore/space, collapse whitespace.
+            fallback_title = title or (
+                os.path.splitext(os.path.basename(file.filename or ""))[0]
+                or "Attachment"
+            )
+            safe_title = re.sub(r"[^\w\- ]+", "", fallback_title).strip()
+            safe_title = re.sub(r"\s+", "-", safe_title) or "Attachment"
+            target_path = f"Attachments/{sha256_hex[:12]}/{safe_title}"
+
+            proposed_meta = {
+                "title": fallback_title,
+                "source_filename": file.filename,
+                "blob_id": blob_id,
+                "content_type": "resource",
+            }
+            content_hash = hashlib.sha256((text or "").encode()).hexdigest()
+            initial_status = (
+                "auto_approved" if governance_tier in (1, 2) else "pending"
+            )
+
+            cur = await conn.execute(
+                """
+                INSERT INTO staging (
+                    org_id, target_entry_id, target_path, change_type,
+                    proposed_title, proposed_content, proposed_meta, content_hash,
+                    submitted_by, source,
+                    governance_tier, submission_category,
+                    status, priority
+                ) VALUES (
+                    %(org_id)s, NULL, %(target_path)s, 'create',
+                    %(proposed_title)s, %(proposed_content)s,
+                    %(proposed_meta)s, %(content_hash)s,
+                    %(submitted_by)s, %(source)s,
+                    %(governance_tier)s, 'attachment_digest',
+                    %(status)s, 3
+                )
+                RETURNING id, org_id, target_entry_id, target_path, change_type,
+                          proposed_title, proposed_content, proposed_meta,
+                          submitted_by, source, governance_tier,
+                          submission_category, status
+                """,
+                {
+                    "org_id": user.org_id,
+                    "target_path": target_path,
+                    "proposed_title": fallback_title,
+                    "proposed_content": text or "",
+                    "proposed_meta": json.dumps(proposed_meta),
+                    "content_hash": content_hash,
+                    "submitted_by": user.id,
+                    "source": user.source,
+                    "governance_tier": governance_tier,
+                    "status": initial_status,
+                },
+            )
+            cur.row_factory = dict_row
+            staging_row = await cur.fetchone()
+            response["staging_id"] = str(staging_row["id"])
+
+            # Tier 1/2 auto-promotion: mirror submit_staging's fast path.
+            # Escalating to kb_admin is required because kb_agent/kb_editor
+            # cannot INSERT into entries; the existing submit_staging flow
+            # does the same dance. _promote_staging_item will also insert
+            # the entry_attachments row via the digest hook we added to it.
+            if governance_tier in (1, 2):
+                await conn.execute("SET LOCAL ROLE kb_admin")
+                # _promote_staging_item expects a dict with proposed_meta as
+                # a python dict — but the RETURNING gave us the JSONB parsed
+                # as a dict already, which psycopg does by default.
+                entry_row = await _promote_staging_item(
+                    conn, staging_row, user.id
+                )
+                await conn.execute(
+                    "UPDATE staging SET promoted_entry_id = %s WHERE id = %s",
+                    (entry_row["id"], staging_row["id"]),
+                )
+
+        return response
+
+
+# ---------------------------------------------------------------------------
+# GET /attachments/_local/{key:path} — signed-URL handler for LocalStorage
+# ---------------------------------------------------------------------------
+#
+# IMPORTANT: this route is registered BEFORE `GET /attachments/{blob_id}` so
+# the `_local` literal prefix wins over the parameterized match. FastAPI
+# matches in registration order for ambiguous paths.
+#
+# The `_local` path is only meaningful when `STORAGE_BACKEND=local`.
+# Signatures are HMAC'd by `services.storage.LocalStorage` and verified here
+# via `verify_local_signed_url(key, exp, sig)`. Auth is intentionally not
+# required — the signed URL itself is the bearer token, with a 5-minute TTL
+# enforced by the HMAC payload.
+
+
+@router.get("/_local/{key:path}")
+async def get_local_signed(
+    key: str,
+    request: Request,
+    exp: str = Query(..., description="Signed URL expiry (unix seconds)"),
+    sig: str = Query(..., description="HMAC-SHA256 signature"),
+):
+    """Serve the bytes for a LocalStorage-backed blob via a signed URL.
+
+    Verifies the HMAC signature + expiry; 403s on any failure. On success
+    reads the bytes through the LocalStorage backend and returns them with
+    the caller-hinted Content-Type (falling back to `mimetypes.guess_type`
+    on the storage key, then `application/octet-stream`).
+    """
+    backend = (os.environ.get("STORAGE_BACKEND") or "local").strip().lower()
+    if backend != "local":
+        # Shouldn't be reachable in non-local mode — signed URLs are only
+        # minted by LocalStorage — but fail closed if a caller crafts one.
+        raise HTTPException(status_code=404, detail="Not found")
+
+    if not verify_local_signed_url(key, exp, sig):
+        raise HTTPException(status_code=403, detail="Invalid or expired signature")
+
+    storage = get_storage()
+    try:
+        data = await storage.get(key)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Blob not found")
+    except ValueError:
+        # `_path_for` rejects traversal attempts.
+        raise HTTPException(status_code=400, detail="Invalid storage key")
+
+    # Prefer the content-type recorded on the blobs row when we can look it
+    # up, but the signed URL handler runs unauthenticated so we can't filter
+    # by RLS here. Do a raw-pool lookup by storage_key (keys are globally
+    # unique within a backend: {org_id}/{sha[:2]}/{sha}). Falls back to a
+    # mimetype guess if the row is missing.
+    content_type = "application/octet-stream"
+    try:
+        pool = get_pool()
+        async with pool.connection() as conn:
+            cur = await conn.execute(
+                "SELECT content_type FROM blobs WHERE storage_key = %s LIMIT 1",
+                (key,),
+            )
+            row = await cur.fetchone()
+            if row and row[0]:
+                content_type = row[0]
+            else:
+                guess, _ = mimetypes.guess_type(key)
+                if guess:
+                    content_type = guess
+    except Exception:
+        # Lookup is a nice-to-have; never block byte delivery on it.
+        guess, _ = mimetypes.guess_type(key)
+        if guess:
+            content_type = guess
+
+    return Response(content=data, media_type=content_type)
+
+
+# ---------------------------------------------------------------------------
+# GET /attachments/{blob_id} — auth-gated 302 redirect to signed URL
+# ---------------------------------------------------------------------------
+
+
+@router.get("/{blob_id}")
+async def get_attachment(
+    blob_id: str,
+    user: UserContext = Depends(get_current_user),
+):
+    """Return a 302 redirect to a time-limited signed URL for this blob.
+
+    Visibility model (two-step):
+
+    1. Under the caller's RLS context, probe `entry_attachments` joined to
+       `entries`. Entry RLS (004/011/019) filters out entries the caller
+       cannot see, and the `entry_attachments_select_via_entry` policy
+       further hides attachment rows whose entry is invisible. If no row
+       is returned, the caller either has no entry with this blob attached
+       or the blob doesn't exist — either way we answer **404** to avoid
+       leaking existence of blobs the caller has no read access to.
+
+    2. After authorization clears, fetch the blob's storage pointer via a
+       raw pool connection (superuser, bypasses RLS). This two-stage split
+       keeps authorization entirely in RLS while letting the signer access
+       the `storage_key` without needing a role that can SELECT all blobs.
+
+    Returns 302 with `Location:` set to `Storage.signed_url(key, ttl=300)`.
+    """
+    # --- Step 1: authorization under user RLS ---
+    async with get_db(user) as conn:
+        cur = await conn.execute(
+            """
+            SELECT 1
+            FROM entry_attachments ea
+            JOIN entries e ON e.id = ea.entry_id
+            WHERE ea.blob_id = %s
+            LIMIT 1
+            """,
+            (blob_id,),
+        )
+        has_access = await cur.fetchone()
+
+    if has_access is None:
+        # Don't leak existence — 404 whether the blob doesn't exist or the
+        # caller just can't see any entry that references it.
+        raise HTTPException(status_code=404, detail="Not found")
+
+    # --- Step 2: fetch storage pointer bypassing RLS ---
+    pool = get_pool()
+    async with pool.connection() as conn:
+        cur = await conn.execute(
+            "SELECT storage_backend, storage_key FROM blobs WHERE id = %s",
+            (blob_id,),
+        )
+        cur.row_factory = dict_row
+        blob = await cur.fetchone()
+
+    if blob is None:
+        # Shouldn't happen — authorization just confirmed an attachment row
+        # referencing this blob_id — but guard against races / FK gaps.
+        raise HTTPException(status_code=404, detail="Not found")
+
+    storage = get_storage()
+    url = storage.signed_url(blob["storage_key"], ttl_seconds=300)
+
+    return RedirectResponse(url=url, status_code=302)

--- a/api/routes/entries.py
+++ b/api/routes/entries.py
@@ -9,6 +9,8 @@ from psycopg.rows import dict_row
 from auth import UserContext, get_current_user
 from database import get_db
 from models import (
+    AttachmentResponse,
+    BlobResponse,
     EntryAppend,
     EntryCreate,
     EntryList,
@@ -530,3 +532,58 @@ async def delete_entry(
             raise HTTPException(status_code=404, detail="Entry not found")
 
         return {"message": "Entry archived"}
+
+
+@router.get("/{entry_id}/attachments", response_model=list[AttachmentResponse])
+async def list_entry_attachments(
+    entry_id: str,
+    user: UserContext = Depends(get_current_user),
+):
+    """List attachments on an entry, filtered by RLS.
+
+    Entry visibility is enforced by the entries RLS policies; the
+    `entry_attachments_select_via_entry` policy further hides attachment
+    rows whose owning entry the caller can't see. A caller with no access
+    to the entry will get an empty list — the same shape as an entry with
+    no attachments, which keeps cross-org probing quiet.
+    """
+    async with get_db(user) as conn:
+        cur = await conn.execute(
+            """
+            SELECT
+                ea.id            AS attachment_id,
+                ea.entry_id      AS entry_id,
+                ea.blob_id       AS blob_id,
+                ea.role          AS role,
+                ea.created_at    AS attachment_created_at,
+                b.sha256         AS sha256,
+                b.content_type   AS content_type,
+                b.size_bytes     AS size_bytes,
+                b.uploaded_at    AS uploaded_at
+            FROM entry_attachments ea
+            JOIN blobs b ON b.id = ea.blob_id
+            WHERE ea.entry_id = %s
+            ORDER BY ea.created_at ASC
+            """,
+            (entry_id,),
+        )
+        cur.row_factory = dict_row
+        rows = await cur.fetchall()
+
+    return [
+        AttachmentResponse(
+            id=str(r["attachment_id"]),
+            entry_id=str(r["entry_id"]),
+            blob_id=str(r["blob_id"]),
+            role=r["role"],
+            created_at=r["attachment_created_at"],
+            blob=BlobResponse(
+                id=str(r["blob_id"]),
+                sha256=r["sha256"],
+                content_type=r["content_type"],
+                size_bytes=int(r["size_bytes"]),
+                uploaded_at=r["uploaded_at"],
+            ),
+        )
+        for r in rows
+    ]

--- a/api/routes/staging.py
+++ b/api/routes/staging.py
@@ -195,6 +195,27 @@ async def _promote_staging_item(conn, staging: dict, approver_id: str) -> dict:
                 "evaluator_approved",
             ),
         )
+
+        # Attachment-digest hook (T-0183): when the staging row came from
+        # the PDF digest pipeline, the blob is already persisted; link it
+        # to the newly-created entry via entry_attachments(role='source').
+        # The caller (submit_staging / process_staging / approve_staging)
+        # has already escalated to kb_admin before calling us, so the
+        # INSERT bypasses the kb_agent/kb_editor WITH CHECK clause and
+        # still carries proper org_id.
+        if staging.get("submission_category") == "attachment_digest":
+            blob_id = (meta or {}).get("blob_id")
+            if blob_id:
+                await conn.execute(
+                    """
+                    INSERT INTO entry_attachments (
+                        org_id, entry_id, blob_id, role
+                    ) VALUES (%s, %s, %s, 'source')
+                    ON CONFLICT (entry_id, blob_id) DO NOTHING
+                    """,
+                    (staging["org_id"], entry_row["id"], blob_id),
+                )
+
         return entry_row
 
     elif staging["change_type"] == "update":

--- a/api/services/pdf_extract.py
+++ b/api/services/pdf_extract.py
@@ -1,0 +1,131 @@
+"""PDF text extraction for the attachment digest pipeline (spec 0034b, T-0183).
+
+Single entry point: `extract_pdf(data, filename) -> (title, text)`.
+
+Title resolution priority:
+  1. `/Info /Title` metadata embedded in the PDF
+  2. First non-empty line of page 1's extracted text
+  3. The supplied `filename` (with `.pdf` extension stripped) as a fallback
+
+Text is the concatenation of `page.extract_text()` across all pages,
+joined by a blank line. Whitespace is trimmed at the edges.
+
+Error handling is intentionally permissive: any `pypdf` failure (corrupt
+bytes, encrypted PDFs, truncated streams) causes the function to return
+`("", "")` rather than raising. Callers get to decide whether an empty
+digest is still worth staging (the T-0183 route does stage it — a
+staging row with empty content is preferable to a 500 that masks the
+underlying attachment).
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+
+try:  # pypdf is declared in api/requirements.txt; keep the import tolerant
+    from pypdf import PdfReader
+except ImportError:  # pragma: no cover — only hit in environments without pypdf
+    PdfReader = None  # type: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+
+
+def _title_from_metadata(reader: "PdfReader") -> str:
+    """Return the /Info /Title metadata string if present and non-empty."""
+    try:
+        meta = reader.metadata
+    except Exception:  # noqa: BLE001 — any metadata fetch failure is non-fatal
+        return ""
+    if meta is None:
+        return ""
+    # pypdf exposes `title` on the DocumentInformation object, plus the
+    # raw `/Title` key on the dict-like proxy. Try both — some PDFs stash
+    # the title under the dict key without populating the accessor.
+    candidate = ""
+    try:
+        candidate = (getattr(meta, "title", None) or "").strip()
+    except Exception:  # noqa: BLE001
+        candidate = ""
+    if candidate:
+        return candidate
+    try:
+        raw = meta.get("/Title", "") if hasattr(meta, "get") else ""
+        if raw:
+            return str(raw).strip()
+    except Exception:  # noqa: BLE001
+        pass
+    return ""
+
+
+def _title_from_first_page(pages_text: list[str]) -> str:
+    """Return the first non-empty stripped line from the first page, if any."""
+    if not pages_text:
+        return ""
+    first = pages_text[0] or ""
+    for line in first.splitlines():
+        stripped = line.strip()
+        if stripped:
+            # Cap absurdly long "first lines" — some scans have
+            # single-line pages. 200 chars is plenty for a title.
+            return stripped[:200]
+    return ""
+
+
+def _title_from_filename(filename: str | None) -> str:
+    """Strip directory, then a trailing `.pdf` extension (case-insensitive)."""
+    if not filename:
+        return ""
+    base = os.path.basename(filename).strip()
+    if base.lower().endswith(".pdf"):
+        base = base[:-4]
+    return base.strip()
+
+
+def extract_pdf(data: bytes, filename: str | None = None) -> tuple[str, str]:
+    """Extract `(title, text)` from PDF `data`.
+
+    On any pypdf error, returns `("", "")`. The caller decides whether to
+    stage an empty digest, surface an error to the user, or retry with a
+    different pipeline (e.g. OCR for scanned PDFs).
+    """
+    if PdfReader is None:
+        logger.warning("pypdf not installed; extract_pdf returning empty tuple")
+        return ("", "")
+
+    if not data:
+        return ("", _title_from_filename(filename))
+
+    try:
+        reader = PdfReader(io.BytesIO(data))
+    except Exception as exc:  # noqa: BLE001 — corrupt bytes, truncated PDFs, etc.
+        logger.info("extract_pdf: PdfReader failed: %s", exc)
+        return ("", "")
+
+    pages_text: list[str] = []
+    try:
+        for page in reader.pages:
+            try:
+                text = page.extract_text() or ""
+            except Exception as exc:  # noqa: BLE001 — bad page stream
+                logger.info("extract_pdf: page.extract_text failed: %s", exc)
+                text = ""
+            pages_text.append(text)
+    except Exception as exc:  # noqa: BLE001 — reader.pages iteration itself failed
+        logger.info("extract_pdf: pages iteration failed: %s", exc)
+        return ("", "")
+
+    full_text = "\n\n".join(pt for pt in pages_text).strip()
+
+    title = _title_from_metadata(reader)
+    if not title:
+        title = _title_from_first_page(pages_text)
+    if not title:
+        title = _title_from_filename(filename)
+
+    return (title, full_text)
+
+
+__all__ = ["extract_pdf"]

--- a/api/services/storage.py
+++ b/api/services/storage.py
@@ -1,0 +1,362 @@
+"""Blob storage abstraction for file attachments (spec 0034b, T-0181).
+
+Exports a `Storage` protocol with two concrete implementations:
+
+* `LocalStorage` — writes blobs to a local filesystem tree
+  (`{root}/{org_id}/{sha[:2]}/{sha}`) and issues HMAC-signed URLs that
+  the API itself serves via `GET /attachments/_local/{key}?exp=...&sig=...`.
+* `S3Storage` — uses `boto3` with a configurable endpoint URL
+  (works with AWS, Cloudflare R2, and MinIO). Lazy-imports boto3 inside
+  `__init__` so importing this module doesn't require boto3 to be present.
+
+Backend selection is via the `STORAGE_BACKEND` environment variable
+(`local` default, `s3` alternative). Factory `get_storage()` returns
+the appropriate instance.
+
+Also exports `verify_local_signed_url(key, exp, sig) -> bool` which the
+local-serving handler (wired in T-0184) calls to validate signed URLs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hmac
+import hashlib
+import os
+import secrets
+import time
+import urllib.parse
+from pathlib import Path
+from typing import Optional, Protocol
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+class Storage(Protocol):
+    """Abstract blob-storage backend.
+
+    Implementations must be safe to call across async handlers — either
+    natively async or using `run_in_executor` under the hood for blocking
+    I/O (the local/S3 impls here use the latter pattern).
+    """
+
+    async def put(
+        self, org_id: str, sha256: str, content_type: str, data: bytes
+    ) -> str:
+        """Persist `data` and return an opaque `storage_key` string.
+
+        The storage_key is what we write into `blobs.storage_key` — it
+        must be sufficient for `get`/`delete`/`signed_url` to locate the
+        object without further context.
+        """
+        ...
+
+    async def get(self, storage_key: str) -> bytes:
+        """Return the raw bytes for a previously-stored blob."""
+        ...
+
+    async def delete(self, storage_key: str) -> None:
+        """Remove the blob identified by `storage_key`. Idempotent."""
+        ...
+
+    def signed_url(self, storage_key: str, ttl_seconds: int = 300) -> str:
+        """Return a time-limited URL the caller can hand to an HTTP client."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Local filesystem backend
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_LOCAL_ROOT = "/data/uploads"
+_SIGNING_KEY_FILENAME = ".signing_key"
+
+
+def _load_or_create_signing_key(root: Path) -> bytes:
+    """Return the HMAC signing key for local signed URLs.
+
+    Precedence:
+
+    1. `LOCAL_STORAGE_SIGNING_KEY` env var (hex-decoded if possible,
+       otherwise used as raw UTF-8 bytes).
+    2. A persisted key file at `{root}/.signing_key`, created on first
+       call with 32 bytes from `secrets.token_bytes`.
+
+    Persisting to disk means all workers in the same process group share
+    the same key and signed URLs survive container restarts as long as
+    the storage volume is mounted.
+    """
+    env_key = os.environ.get("LOCAL_STORAGE_SIGNING_KEY")
+    if env_key:
+        try:
+            return bytes.fromhex(env_key)
+        except ValueError:
+            return env_key.encode("utf-8")
+
+    root.mkdir(parents=True, exist_ok=True)
+    key_path = root / _SIGNING_KEY_FILENAME
+    if key_path.exists():
+        data = key_path.read_bytes()
+        if data:
+            return data
+    key = secrets.token_bytes(32)
+    # Write atomically-ish: write to a temp file then rename.
+    tmp = key_path.with_suffix(".tmp")
+    tmp.write_bytes(key)
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    os.replace(tmp, key_path)
+    return key
+
+
+def _sign(key: bytes, payload: str) -> str:
+    return hmac.new(key, payload.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+class LocalStorage:
+    """Filesystem-backed `Storage` implementation.
+
+    Layout: `{root}/{org_id}/{sha[:2]}/{sha}`.
+
+    `storage_key` format: `{org_id}/{sha[:2]}/{sha}` (relative to `root`,
+    always forward-slash separated so it round-trips through URLs and
+    across OSes).
+    """
+
+    def __init__(
+        self,
+        root: Optional[str] = None,
+        signing_key: Optional[bytes] = None,
+        url_prefix: str = "/attachments/_local",
+    ) -> None:
+        self.root = Path(root or os.environ.get("LOCAL_STORAGE_ROOT") or _DEFAULT_LOCAL_ROOT)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._signing_key = signing_key or _load_or_create_signing_key(self.root)
+        self._url_prefix = url_prefix.rstrip("/")
+
+    # -- internal helpers -----------------------------------------------
+
+    def _path_for(self, storage_key: str) -> Path:
+        # Storage keys are trusted (we generated them) but defensively
+        # reject absolute or `..`-containing segments — these should
+        # never happen via `put`, but guard against misuse of `get`.
+        parts = [p for p in storage_key.split("/") if p]
+        if any(p in ("..", ".") or p.startswith("/") for p in parts):
+            raise ValueError(f"Invalid storage_key: {storage_key!r}")
+        return self.root.joinpath(*parts)
+
+    # -- protocol methods -----------------------------------------------
+
+    async def put(
+        self, org_id: str, sha256: str, content_type: str, data: bytes
+    ) -> str:
+        # content_type is accepted for parity with S3Storage (which uses
+        # it as Content-Type metadata); LocalStorage doesn't persist it
+        # because the blobs row is the source of truth.
+        del content_type
+        if not sha256 or len(sha256) < 4:
+            raise ValueError("sha256 must be the full hex digest")
+        key = f"{org_id}/{sha256[:2]}/{sha256}"
+
+        def _write() -> None:
+            path = self._path_for(key)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(".part")
+            tmp.write_bytes(data)
+            os.replace(tmp, path)
+
+        await asyncio.get_event_loop().run_in_executor(None, _write)
+        return key
+
+    async def get(self, storage_key: str) -> bytes:
+        path = self._path_for(storage_key)
+
+        def _read() -> bytes:
+            return path.read_bytes()
+
+        return await asyncio.get_event_loop().run_in_executor(None, _read)
+
+    async def delete(self, storage_key: str) -> None:
+        path = self._path_for(storage_key)
+
+        def _delete() -> None:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+
+        await asyncio.get_event_loop().run_in_executor(None, _delete)
+
+    def signed_url(self, storage_key: str, ttl_seconds: int = 300) -> str:
+        exp = int(time.time()) + int(ttl_seconds)
+        sig = _sign(self._signing_key, f"{storage_key}:{exp}")
+        quoted = urllib.parse.quote(storage_key, safe="/")
+        return f"{self._url_prefix}/{quoted}?exp={exp}&sig={sig}"
+
+    # -- verification ---------------------------------------------------
+
+    def verify(self, storage_key: str, exp: int | str, sig: str) -> bool:
+        """Check a local signed URL's expiry and HMAC signature."""
+        try:
+            exp_int = int(exp)
+        except (TypeError, ValueError):
+            return False
+        if exp_int < int(time.time()):
+            return False
+        expected = _sign(self._signing_key, f"{storage_key}:{exp_int}")
+        return hmac.compare_digest(expected, sig or "")
+
+
+# Module-level verifier for import from route handlers. A fresh
+# `LocalStorage` instance is cheap and uses the same signing key
+# (either env-provided or persisted on disk), so verification from a
+# request handler doesn't need to reach into the active instance.
+def verify_local_signed_url(storage_key: str, exp: int | str, sig: str) -> bool:
+    """Verify a signed URL produced by `LocalStorage.signed_url`.
+
+    Returns False if expired, tampered, or malformed. Intended to be
+    called from the `/attachments/_local/{key}` handler wired up by
+    T-0184.
+    """
+    return LocalStorage().verify(storage_key, exp, sig)
+
+
+# ---------------------------------------------------------------------------
+# S3-compatible backend
+# ---------------------------------------------------------------------------
+
+
+class S3Storage:
+    """S3-compatible `Storage` implementation (AWS / R2 / MinIO).
+
+    Configuration (all via environment variables):
+
+    * `S3_BUCKET` — required.
+    * `S3_ENDPOINT_URL` — optional; set for R2/MinIO, unset for AWS.
+    * `S3_ACCESS_KEY`, `S3_SECRET_KEY` — optional; fall back to boto3's
+      default credential chain (IAM roles, shared config, etc.).
+    * `S3_REGION` — optional; defaults to `auto` (friendly for R2).
+
+    `boto3` is imported lazily inside `__init__` so callers that select
+    a non-S3 backend don't need the package installed.
+    """
+
+    def __init__(
+        self,
+        bucket: Optional[str] = None,
+        endpoint_url: Optional[str] = None,
+        access_key: Optional[str] = None,
+        secret_key: Optional[str] = None,
+        region: Optional[str] = None,
+    ) -> None:
+        import boto3  # noqa: WPS433 — lazy on purpose
+
+        self.bucket = bucket or os.environ.get("S3_BUCKET")
+        if not self.bucket:
+            raise RuntimeError(
+                "S3Storage requires S3_BUCKET env var (or bucket= kwarg)"
+            )
+        endpoint = endpoint_url or os.environ.get("S3_ENDPOINT_URL") or None
+        ak = access_key or os.environ.get("S3_ACCESS_KEY") or None
+        sk = secret_key or os.environ.get("S3_SECRET_KEY") or None
+        reg = region or os.environ.get("S3_REGION") or "auto"
+
+        self._client = boto3.client(
+            "s3",
+            endpoint_url=endpoint,
+            aws_access_key_id=ak,
+            aws_secret_access_key=sk,
+            region_name=reg,
+        )
+
+    @staticmethod
+    def _key_for(org_id: str, sha256: str) -> str:
+        return f"{org_id}/{sha256[:2]}/{sha256}"
+
+    async def put(
+        self, org_id: str, sha256: str, content_type: str, data: bytes
+    ) -> str:
+        key = self._key_for(org_id, sha256)
+
+        def _put() -> None:
+            self._client.put_object(
+                Bucket=self.bucket,
+                Key=key,
+                Body=data,
+                ContentType=content_type or "application/octet-stream",
+            )
+
+        await asyncio.get_event_loop().run_in_executor(None, _put)
+        return key
+
+    async def get(self, storage_key: str) -> bytes:
+        def _get() -> bytes:
+            resp = self._client.get_object(Bucket=self.bucket, Key=storage_key)
+            return resp["Body"].read()
+
+        return await asyncio.get_event_loop().run_in_executor(None, _get)
+
+    async def delete(self, storage_key: str) -> None:
+        def _delete() -> None:
+            self._client.delete_object(Bucket=self.bucket, Key=storage_key)
+
+        await asyncio.get_event_loop().run_in_executor(None, _delete)
+
+    def signed_url(self, storage_key: str, ttl_seconds: int = 300) -> str:
+        return self._client.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": self.bucket, "Key": storage_key},
+            ExpiresIn=int(ttl_seconds),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+_STORAGE_SINGLETON: Optional[Storage] = None
+
+
+def get_storage() -> Storage:
+    """Return the configured `Storage` instance (cached per-process).
+
+    Selected by the `STORAGE_BACKEND` env var (`local` | `s3`, default
+    `local`). The instance is created on first call and reused on
+    subsequent calls so HMAC signing keys stay consistent within a
+    process.
+    """
+    global _STORAGE_SINGLETON
+    if _STORAGE_SINGLETON is not None:
+        return _STORAGE_SINGLETON
+    backend = (os.environ.get("STORAGE_BACKEND") or "local").strip().lower()
+    if backend == "s3":
+        _STORAGE_SINGLETON = S3Storage()
+    elif backend == "local":
+        _STORAGE_SINGLETON = LocalStorage()
+    else:
+        raise RuntimeError(
+            f"Unknown STORAGE_BACKEND={backend!r}; expected 'local' or 's3'"
+        )
+    return _STORAGE_SINGLETON
+
+
+def _reset_storage_singleton_for_tests() -> None:
+    """Test-only: clear the cached singleton so env changes take effect."""
+    global _STORAGE_SINGLETON
+    _STORAGE_SINGLETON = None
+
+
+__all__ = [
+    "Storage",
+    "LocalStorage",
+    "S3Storage",
+    "get_storage",
+    "verify_local_signed_url",
+]

--- a/db/migrations/022_blobs_and_attachments.sql
+++ b/db/migrations/022_blobs_and_attachments.sql
@@ -1,0 +1,170 @@
+-- 022_blobs_and_attachments.sql
+-- File uploads: blob store + entry attachment join table.
+--
+-- Adds two tables:
+--   blobs             -- immutable, content-addressed file records (sha256 per org)
+--   entry_attachments -- many-to-many link between entries and blobs
+--
+-- Storage bytes live in an external backend (local FS or S3-compatible); the
+-- blobs row carries the pointer (storage_backend, storage_key). Blob rows are
+-- deduped per-org by sha256 — the same content uploaded twice by the same org
+-- yields a single blobs row; the same bytes uploaded by two different orgs
+-- yields two rows (so tenant isolation holds even if the backend is shared).
+--
+-- RLS mirrors the entries pattern:
+--   - FORCE ROW LEVEL SECURITY; all policies key off current_setting('app.org_id')
+--   - kb_admin has full CRUD within org
+--   - kb_editor + kb_agent can SELECT + INSERT within org (no UPDATE/DELETE —
+--     blobs are immutable once written; attachments get deleted via ON DELETE
+--     CASCADE from entries, not directly)
+--   - kb_commenter + kb_viewer get SELECT only
+--   - entry_attachments SELECT further joins to entries so entry RLS (004 + 011
+--     + 019) transparently filters attachment visibility
+--
+-- Idempotent: safe to re-run. Uses CREATE TABLE IF NOT EXISTS, CREATE INDEX
+-- IF NOT EXISTS, and DROP POLICY IF EXISTS before each CREATE POLICY.
+--
+-- Spec: 0034b — File uploads / PDF digest
+-- Task: T-0180
+-- Depends on: 001_core.sql, 004_rls.sql
+
+-- =============================================================================
+-- BLOBS — content-addressed blob store
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS blobs (
+    id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id            TEXT NOT NULL REFERENCES organizations(id),
+    sha256            TEXT NOT NULL,
+    content_type      TEXT NOT NULL,
+    size_bytes        BIGINT NOT NULL,
+    storage_backend   TEXT NOT NULL,
+    storage_key       TEXT NOT NULL,
+    uploaded_by       TEXT NOT NULL REFERENCES users(id),
+    uploaded_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    UNIQUE (org_id, sha256)
+);
+
+-- Covering index for dedup lookups (already satisfied by the UNIQUE constraint
+-- above, but declared explicitly for clarity and EXPLAIN readability).
+CREATE INDEX IF NOT EXISTS idx_blobs_org_sha256 ON blobs (org_id, sha256);
+
+-- =============================================================================
+-- ENTRY_ATTACHMENTS — many-to-many link between entries and blobs
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS entry_attachments (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id      TEXT NOT NULL REFERENCES organizations(id),
+    entry_id    UUID NOT NULL REFERENCES entries(id) ON DELETE CASCADE,
+    blob_id     UUID NOT NULL REFERENCES blobs(id),
+    role        TEXT NOT NULL DEFAULT 'source'
+                    CHECK (role IN ('source', 'derived', 'thumbnail')),
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    UNIQUE (entry_id, blob_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_entry_attachments_entry ON entry_attachments (entry_id);
+CREATE INDEX IF NOT EXISTS idx_entry_attachments_blob  ON entry_attachments (blob_id);
+
+-- =============================================================================
+-- GRANT TABLE PERMISSIONS TO PG ROLES
+-- =============================================================================
+
+-- kb_admin: full CRUD on both tables
+GRANT SELECT, INSERT, UPDATE, DELETE ON blobs, entry_attachments TO kb_admin;
+
+-- kb_editor, kb_agent: can add blobs/attachments (upload path) + read
+GRANT SELECT, INSERT ON blobs, entry_attachments TO kb_editor, kb_agent;
+
+-- kb_commenter, kb_viewer: read-only
+GRANT SELECT ON blobs, entry_attachments TO kb_commenter, kb_viewer;
+
+-- =============================================================================
+-- ROW-LEVEL SECURITY — blobs
+-- =============================================================================
+
+ALTER TABLE blobs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE blobs FORCE ROW LEVEL SECURITY;
+
+-- kb_admin: full access within org
+DROP POLICY IF EXISTS blobs_admin_all ON blobs;
+CREATE POLICY blobs_admin_all ON blobs
+    TO kb_admin
+    USING      (org_id = current_setting('app.org_id'))
+    WITH CHECK (org_id = current_setting('app.org_id'));
+
+-- Non-admin roles: SELECT within org
+DROP POLICY IF EXISTS blobs_select_org ON blobs;
+CREATE POLICY blobs_select_org ON blobs
+    FOR SELECT
+    TO kb_editor, kb_commenter, kb_viewer, kb_agent
+    USING (org_id = current_setting('app.org_id'));
+
+-- kb_editor, kb_agent: INSERT within org (uploader must match current user)
+DROP POLICY IF EXISTS blobs_insert_editor_agent ON blobs;
+CREATE POLICY blobs_insert_editor_agent ON blobs
+    FOR INSERT
+    TO kb_editor, kb_agent
+    WITH CHECK (
+        org_id = current_setting('app.org_id')
+        AND uploaded_by = current_setting('app.user_id')
+    );
+
+-- No UPDATE or DELETE policies for non-admin roles: blobs are immutable once
+-- written. Admins can still clean up via blobs_admin_all.
+
+-- =============================================================================
+-- ROW-LEVEL SECURITY — entry_attachments
+-- =============================================================================
+
+ALTER TABLE entry_attachments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE entry_attachments FORCE ROW LEVEL SECURITY;
+
+-- kb_admin: full access within org
+DROP POLICY IF EXISTS entry_attachments_admin_all ON entry_attachments;
+CREATE POLICY entry_attachments_admin_all ON entry_attachments
+    TO kb_admin
+    USING      (org_id = current_setting('app.org_id'))
+    WITH CHECK (org_id = current_setting('app.org_id'));
+
+-- Non-admin roles: SELECT iff the referenced entry is visible to the caller.
+-- Defers to entries RLS via the sub-select: a caller who cannot SELECT the
+-- entry gets zero rows for entries.id, so the IN clause filters the
+-- attachment row out. This is the same pattern used by comments (017).
+DROP POLICY IF EXISTS entry_attachments_select_via_entry ON entry_attachments;
+CREATE POLICY entry_attachments_select_via_entry ON entry_attachments
+    FOR SELECT
+    TO kb_editor, kb_commenter, kb_viewer, kb_agent
+    USING (
+        org_id = current_setting('app.org_id')
+        AND entry_id IN (
+            SELECT id FROM entries
+            WHERE org_id = current_setting('app.org_id')
+        )
+    );
+
+-- kb_editor, kb_agent: INSERT iff the referenced entry is visible to the
+-- caller AND the referenced blob is in the same org. The entries sub-select
+-- naturally restricts to entries the caller can SELECT (ownership / dept /
+-- ACL rules all flow through).
+DROP POLICY IF EXISTS entry_attachments_insert_editor_agent ON entry_attachments;
+CREATE POLICY entry_attachments_insert_editor_agent ON entry_attachments
+    FOR INSERT
+    TO kb_editor, kb_agent
+    WITH CHECK (
+        org_id = current_setting('app.org_id')
+        AND entry_id IN (
+            SELECT id FROM entries
+            WHERE org_id = current_setting('app.org_id')
+        )
+        AND blob_id IN (
+            SELECT id FROM blobs
+            WHERE org_id = current_setting('app.org_id')
+        )
+    );
+
+-- No non-admin UPDATE/DELETE: attachments are torn down via ON DELETE CASCADE
+-- when the owning entry is deleted; admins can clean up directly.

--- a/db/migrations/023_staging_attachment_digest.sql
+++ b/db/migrations/023_staging_attachment_digest.sql
@@ -1,0 +1,15 @@
+-- 023_staging_attachment_digest.sql
+-- Expand staging.submission_category CHECK constraint to include
+-- 'attachment_digest' so PDF digest uploads (spec 0034b, T-0183) can
+-- route through the normal Tier 1/2 staging flow.
+--
+-- Depends on: 003_governance.sql
+-- Idempotent: safe to re-run.
+
+ALTER TABLE staging DROP CONSTRAINT IF EXISTS staging_submission_category_check;
+ALTER TABLE staging ADD CONSTRAINT staging_submission_category_check
+    CHECK (submission_category IN (
+        'teaching_loop', 'auto_save', 'compress', 'preserve',
+        'meeting_intel', 'project_intel', 'user_direct',
+        'attachment_digest'
+    ));

--- a/docs/ATTACHMENTS.md
+++ b/docs/ATTACHMENTS.md
@@ -1,0 +1,138 @@
+# Attachments
+
+File attachments let users and agents upload arbitrary files to Brilliant, dedupe them by content hash, and — for PDFs — digest them straight into staged entries for normal Tier 1/2 review. Added in v0.3.0 (spec [`0034b`](../.xireactor/specs/0034b--2026-04-16--sprint-lane2-file-uploads.md), issue [#17](https://github.com/thejeremyhodge/xireactor-brilliant/issues/17)).
+
+For exact request/response shapes, see [`skill/references/api-reference.md` Section 16](../skill/references/api-reference.md). This doc covers the model and operational concerns only.
+
+## Overview
+
+Two tables back the feature:
+
+- **`blobs`** — content-addressed binary objects. One row per unique `(org_id, sha256)` pair. Tracks `content_type`, `size_bytes`, `storage_backend`, `storage_key`, `uploaded_by`, `uploaded_at`.
+- **`entry_attachments`** — join table. Connects `entry_id → blob_id` with a `role` (`source`, `reference`, etc.) and `created_at`.
+
+Uploads always land in `blobs` first. Attaching a blob to an entry is a separate concern (for PDF digests, the system creates the staged entry and the link automatically).
+
+## Storage Backends
+
+Choose the backend via the `STORAGE_BACKEND` env var. Both backends implement the same `Storage` protocol in `api/services/storage.py`, so switching is a config change — no code edits.
+
+| Var | Backend | Purpose |
+|---|---|---|
+| `STORAGE_BACKEND` | `local` \| `s3` | Selects the implementation (default `local`). |
+| `LOCAL_STORAGE_ROOT` | `local` | Root dir for blob files. Default `/data/uploads`. Blobs land at `{root}/{org_id}/{sha[:2]}/{sha}`. |
+| `LOCAL_STORAGE_SIGNING_KEY` | `local` | HMAC key for signing download URLs. Auto-generated and persisted to `{root}/.signing_key` if unset. |
+| `S3_ENDPOINT_URL` | `s3` | Full endpoint (e.g. `https://<account>.r2.cloudflarestorage.com`). Leave unset for real AWS. |
+| `S3_BUCKET` | `s3` | Target bucket. |
+| `S3_ACCESS_KEY` / `S3_SECRET_KEY` | `s3` | Credentials. |
+| `S3_REGION` | `s3` | Region (e.g. `us-east-1`, `auto` for R2). Default `auto`. |
+| `MAX_ATTACHMENT_BYTES` | both | Per-upload size cap. Default 50 MiB. Exceeding returns 413. |
+
+**Local** is the default and the right choice for single-node deployments. Files live under `LOCAL_STORAGE_ROOT`; signed URLs point back to the API at `GET /attachments/_local/{key}?exp=...&sig=...` and are validated against the HMAC key.
+
+**S3** covers AWS S3, Cloudflare R2, and MinIO (and any other endpoint that speaks the S3 API). Signed URLs in this mode are S3 presigned URLs pointing directly at the object store — the API is out of the bytes path.
+
+## Retention
+
+- Blobs are kept **indefinitely**. There is no TTL or auto-cleanup in v1.
+- Deleting an entry cascades to its `entry_attachments` rows (via FK) but **does not** delete the underlying blob. This is dedup-safe: the same blob may be attached to other entries in the same org.
+- **Orphan-blob GC is out of scope for v1.** A follow-up task will add a reaper for blobs with zero `entry_attachments` rows older than N days. Track if/when operators report storage cost pressure.
+
+## Dedup Semantics
+
+Deduplication is scoped to `(org_id, sha256)`:
+
+- Uploading identical bytes to the **same org** twice returns the original `blob_id` with `"dedup": true` on the second call. No second copy is written to storage.
+- Uploading identical bytes to **different orgs** produces **two distinct `blob_id`s** with independent storage keys. There is no cross-org dedup — tenant isolation takes precedence over storage efficiency.
+
+This keeps the RLS model simple: a blob belongs to one org, full stop. Auditors do not need to reason about shared-content edge cases across tenants.
+
+## Permission Model
+
+Blob reads are gated by **entry visibility**, not by direct blob ownership.
+
+To `GET /attachments/{blob_id}`, the caller must have read access (via RLS) to at least one entry that references the blob through `entry_attachments`. The evaluation:
+
+1. Resolve all entries linked to the blob.
+2. Filter through the caller's entry RLS.
+3. If any survive → issue a 302 to a signed URL.
+4. If none survive (or the blob does not exist) → return **404**.
+
+**404, not 403.** Returning 403 would confirm the blob exists to an unauthorized caller, which leaks existence. The 404 covers both "does not exist" and "you cannot see any entry using it."
+
+Uploads (`POST /attachments`) require any authenticated user; the blob is tagged with the caller's `org_id` from the auth context.
+
+## API Cheatsheet
+
+Full specs in [api-reference.md §16](../skill/references/api-reference.md). Quick reference:
+
+```bash
+# Upload a PDF and digest it into a staged entry
+curl -X POST "http://localhost:8010/attachments?digest=true&content_type=application/pdf" \
+  -H "Authorization: Bearer $KEY" \
+  -F "file=@./whitepaper.pdf"
+# → { "blob_id": "...", "sha256": "...", "dedup": false, "staging_id": "..." }
+
+# Follow the redirect to fetch the original
+curl -L "http://localhost:8010/attachments/$BLOB_ID" \
+  -H "Authorization: Bearer $KEY" -o whitepaper.pdf
+
+# List attachments on an entry
+curl "http://localhost:8010/entries/$ENTRY_ID/attachments" \
+  -H "Authorization: Bearer $KEY"
+```
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/attachments` | Multipart upload. `?digest=true&content_type=application/pdf` triggers PDF digestion. |
+| `GET` | `/attachments/{blob_id}` | 302 to a 5-minute signed URL, or 404 if unreachable. |
+| `GET` | `/entries/{id}/attachments` | List attachments on an entry. |
+
+## MCP Tool
+
+Co-work sessions call `upload_attachment` instead of crafting multipart requests directly:
+
+```python
+upload_attachment(path, digest=True, content_type=None) -> dict
+```
+
+- `path` — absolute path readable by the MCP server process. For Docker-hosted MCP, the file must live on a bind-mounted volume.
+- `digest` — defaults to `True`. When combined with a PDF, triggers the staged-entry pipeline.
+- `content_type` — explicit override. When omitted, derived from the file extension; falls back to `application/octet-stream`.
+
+Returns the `POST /attachments` response verbatim (see api-reference §16a).
+
+**Example session:**
+
+```
+> upload_attachment("/workspace/inbox/q4-plan.pdf")
+{ "blob_id": "...", "sha256": "...", "staging_id": "stg_..." }
+
+> list_staging()
+# Shows q4-plan.pdf digest queued for review
+
+> review_staging("stg_...", "approve")
+# Entry promoted, entry_attachments row linked back to the blob
+```
+
+## PDF Digestion Flow
+
+Triggered by `POST /attachments?digest=true&content_type=application/pdf` (or the MCP tool with a `.pdf`):
+
+1. **Upload & dedup** — Bytes are hashed and persisted as a blob. Duplicates short-circuit here.
+2. **Extract** — `api/services/pdf_extract.py` uses `pypdf` to pull text from the PDF. Title is taken from PDF metadata, falling back to the filename stem.
+3. **Stage** — A single staged entry is created with `submission_category='attachment_digest'`, content set to the extracted text. The entry enters the **normal Tier 1/2 staging flow** — no special-casing downstream.
+4. **Link on approval** — When the staged entry is approved, a row is written to `entry_attachments(entry_id, blob_id, role='source')`. The original PDF is now retrievable via `GET /attachments/{blob_id}` for any user who can see the entry.
+
+**Limits:**
+
+- `pypdf` handles born-digital PDFs well. **Scanned PDFs produce empty or garbage text.** OCR is out of scope for v1 — track a follow-up if users hit it.
+- Only PDFs are digested. Other content types land as raw blobs; attaching them to entries is a manual operation.
+- One staged entry per upload. Multi-document PDFs are not split.
+
+## Follow-ups
+
+- **Orphan-blob GC.** Reap blobs with zero `entry_attachments` rows older than N days.
+- **OCR for scanned PDFs.** Add a Tesseract (or cloud OCR) path when frequency warrants.
+- **More file types.** Images, docx, audio transcripts — each its own digest pipeline.
+- **Per-tenant storage quotas.** Schema already tracks `size_bytes`; enforcement is the next step.

--- a/mcp/client.py
+++ b/mcp/client.py
@@ -52,3 +52,39 @@ class CortexClient:
 
     async def delete(self, path: str, *, api_key: str | None = None) -> dict:
         return await self._request("DELETE", path, api_key=api_key)
+
+    async def post_multipart(
+        self,
+        path: str,
+        files: dict,
+        params: dict | None = None,
+        *,
+        api_key: str | None = None,
+    ) -> dict:
+        """POST a multipart/form-data request.
+
+        `files` follows httpx's convention:
+            {"file": (filename, bytes, content_type)}
+
+        The default ``Content-Type: application/json`` header from `_headers`
+        is stripped — httpx must set its own multipart boundary header.
+        """
+        url = f"{self.base_url}{path}"
+        headers = self._headers(api_key)
+        # Let httpx populate the multipart Content-Type (with boundary).
+        headers.pop("Content-Type", None)
+
+        async with httpx.AsyncClient(timeout=60) as http:
+            resp = await http.post(url, headers=headers, files=files, params=params)
+
+        if resp.status_code >= 400:
+            try:
+                body = resp.json()
+            except Exception:
+                body = resp.text
+            return {"error": True, "status": resp.status_code, "detail": body}
+
+        if resp.status_code == 204:
+            return {"ok": True}
+
+        return resp.json()

--- a/mcp/tools.py
+++ b/mcp/tools.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import mimetypes
+from pathlib import Path
+
 from mcp.server.fastmcp import FastMCP
 
 from client import CortexClient
@@ -471,3 +474,81 @@ def register_tools(mcp: FastMCP, api: CortexClient) -> None:
         to roll back. Cannot roll back an already rolled-back batch (returns 409).
         """
         return await api.delete(f"/import/{batch_id}")
+
+    # -------------------------------------------------------------------
+    # Attachment tools
+    # -------------------------------------------------------------------
+
+    @mcp.tool()
+    async def upload_attachment(
+        path: str,
+        digest: bool = True,
+        content_type: str | None = None,
+    ) -> dict:
+        """Upload a local file to Brilliant and optionally digest it into a staged entry.
+
+        Streams the file at `path` to `POST /attachments` as multipart and
+        returns the JSON response. When `digest=True` and the effective
+        content type is `application/pdf`, the server extracts text via
+        pypdf and creates a staged entry (visible via `list_staging`) that,
+        on approval, links back to the stored blob via `entry_attachments`.
+
+        Parameters:
+          path          — absolute path to a local file. The MCP server
+                          process must be able to read the file directly
+                          (`open(path, 'rb')`), which for Docker-hosted
+                          MCP means the file must live on a bind-mounted
+                          volume. Relative paths are resolved against the
+                          MCP server's working directory.
+          digest        — when True and content_type resolves to
+                          `application/pdf`, the upload triggers the PDF
+                          digest pipeline. Ignored for non-PDF uploads.
+          content_type  — explicit MIME override. If None, the type is
+                          derived from the file extension via
+                          `mimetypes.guess_type`, falling back to
+                          `application/octet-stream`.
+
+        Returns the server's JSON verbatim. For successful uploads:
+          {
+            "blob_id": "<uuid>",
+            "sha256": "<hex>",
+            "dedup": <bool>,
+            "size_bytes": <int>,
+            "content_type": "<mime>",
+            "staging_id": "<uuid>"   # only when digest=True and PDF
+          }
+
+        Uploading identical bytes twice within the same org returns
+        `dedup: true` with the original blob_id.
+        """
+        file_path = Path(path)
+        if not file_path.is_file():
+            return {
+                "error": True,
+                "status": 400,
+                "detail": f"File not found or not a regular file: {path}",
+            }
+
+        effective_ct = content_type
+        if effective_ct is None:
+            guessed, _ = mimetypes.guess_type(file_path.name)
+            effective_ct = guessed or "application/octet-stream"
+
+        try:
+            data = file_path.read_bytes()
+        except OSError as exc:
+            return {
+                "error": True,
+                "status": 400,
+                "detail": f"Could not read {path}: {exc}",
+            }
+
+        files = {"file": (file_path.name, data, effective_ct)}
+        params: dict = {"digest": "true" if digest else "false"}
+        # The endpoint uses the `content_type` query param as an override
+        # applied on top of the multipart part's own content-type. Pass
+        # through whatever we resolved so the server's effective type
+        # matches what we sent.
+        params["content_type"] = effective_ct
+
+        return await api.post_multipart("/attachments", files=files, params=params)

--- a/skill/references/api-reference.md
+++ b/skill/references/api-reference.md
@@ -1102,6 +1102,114 @@ curl -s "http://localhost:8010/import/batches?status=rolled_back" \
 
 ---
 
+### 16. Attachments
+
+Upload local files as content-addressed blobs, optionally digest PDFs into staged entries, and retrieve originals via short-lived signed URLs. Blobs are deduped per-org by sha256; cross-org uploads of identical content produce distinct blob rows (tenant isolation holds even with a shared storage backend).
+
+---
+
+#### 16a. Upload Attachment
+
+**`POST /attachments`**
+
+Accepts a multipart file upload. Hashes the bytes on the fly, dedupes against the caller's org, persists via the configured `Storage` backend (local FS or S3-compatible), and returns blob metadata.
+
+**Query parameters:**
+
+| Param | Type | Default | Description |
+|---|---|---|---|
+| `digest` | bool | false | When true **and** the effective content-type is `application/pdf`, extract text via `pypdf` and create a staged entry with `submission_category='attachment_digest'`. On approval, the entry is linked back to the blob via `entry_attachments(role='source')`. |
+| `content_type` | string | null | Explicit MIME override. Used when the uploading client can't set a proper multipart `Content-Type` (e.g. sends `application/octet-stream`). |
+
+**Request body:** multipart/form-data with a single `file` part.
+
+**Size cap:** 50 MiB per request by default; override via the `MAX_ATTACHMENT_BYTES` env var. Exceeding the cap returns **413**.
+
+```bash
+curl -s -X POST "http://localhost:8010/attachments?digest=true&content_type=application/pdf" \
+  -H "Authorization: Bearer bkai_adm1_testkey_admin" \
+  -F "file=@./fixture.pdf"
+```
+
+**Response (201):**
+
+```json
+{
+  "blob_id": "b1c2d3e4-...",
+  "sha256": "c0ffee...",
+  "dedup": false,
+  "size_bytes": 18421,
+  "content_type": "application/pdf",
+  "staging_id": "s1t2u3v4-..."
+}
+```
+
+`staging_id` is present only when `digest=true` and the effective content-type was `application/pdf`. Uploading identical bytes to the same org a second time returns the original `blob_id` with `dedup: true`. Uploading the same bytes to a different org produces a new `blob_id` (no cross-org dedup).
+
+---
+
+#### 16b. Get Attachment
+
+**`GET /attachments/{blob_id}`**
+
+Returns a **302** redirect to a time-limited signed URL (5-minute TTL) for the underlying blob. Authorization is enforced via entry RLS: the caller must have read access to at least one entry that references the blob through `entry_attachments`. Callers without visibility receive **404** (not 403) to avoid leaking blob existence.
+
+```bash
+curl -sI "http://localhost:8010/attachments/b1c2d3e4-..." \
+  -H "Authorization: Bearer bkai_adm1_testkey_admin"
+```
+
+**Response (302):** `Location: <signed URL>` — follow to fetch the bytes. Local-storage signed URLs point to `GET /attachments/_local/{key}?exp=...&sig=...` on the same host; S3-backed deployments return presigned S3 URLs.
+
+**Response (404):** Blob does not exist, or the caller has no read access to any entry referencing it.
+
+---
+
+#### 16c. List Entry Attachments
+
+**`GET /entries/{id}/attachments`**
+
+List blobs attached to an entry, ordered by `created_at`. RLS filters out attachments on entries the caller cannot see.
+
+```bash
+curl -s "http://localhost:8010/entries/e5f6g7h8-.../attachments" \
+  -H "Authorization: Bearer bkai_adm1_testkey_admin"
+```
+
+**Response (200):**
+
+```json
+{
+  "entry_id": "e5f6g7h8-...",
+  "attachments": [
+    {
+      "blob_id": "b1c2d3e4-...",
+      "sha256": "c0ffee...",
+      "content_type": "application/pdf",
+      "size_bytes": 18421,
+      "role": "source",
+      "created_at": "2026-04-16T12:00:00Z"
+    }
+  ]
+}
+```
+
+---
+
+#### 16d. MCP Tool: `upload_attachment`
+
+Exposed to co-work sessions via MCP. Reads a local file path, derives content-type from the extension when not supplied, and posts to `POST /attachments`.
+
+**Signature:** `upload_attachment(path: str, digest: bool = True, content_type: str | None = None) -> dict`
+
+- `path` — absolute path readable by the MCP server process. For Docker-hosted MCP, the file must live on a bind-mounted volume.
+- `digest` — defaults to `True`; triggers the PDF digest pipeline when the effective content-type is `application/pdf`.
+- `content_type` — explicit override; when omitted, derived via `mimetypes.guess_type(path)`, falling back to `application/octet-stream`.
+
+Returns the `POST /attachments` response verbatim (see 16a). Typical end-to-end flow: call `upload_attachment("/path/to.pdf")` → inspect `staging_id` → confirm via `list_staging` → approve via `review_staging` (or let batch processing promote it).
+
+---
+
 ## Valid Enumeration Values
 
 **Content types:** `context`, `project`, `meeting`, `decision`, `intelligence`, `daily`, `resource`, `department`, `team`, `system`, `onboarding`

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,0 +1,775 @@
+"""End-to-end tests for the attachment subsystem (spec 0034b, T-0186).
+
+Exercises the full attachment cycle against the live API + DB stack in
+the `brilliant-uploads` worktree (API on :8020, Postgres on :5452):
+
+  * upload → ``blobs`` row                                 (case 1)
+  * same-org dedup: same sha256 → same ``blob_id``         (case 2)
+  * cross-org isolation: distinct ``blob_id`` + 404 read   (case 3)
+  * digest pipeline → staging → entry + attachment link    (case 4)
+  * signed-URL round-trip: bytes match the upload          (case 5)
+  * permission-404 (not 403) on forbidden ``blob_id``      (case 6)
+  * over-size 413 via ``MAX_ATTACHMENT_BYTES`` override    (case 7)
+
+Prerequisites
+-------------
+  1. ``docker compose up -d``  (API on :8020 in this worktree)
+  2. ``pip install -r tests/requirements-dev.txt``
+  3. Migrations applied through 023 (staging_attachment_digest).
+
+Run
+---
+  pytest tests/test_attachments.py -q
+
+Minimal overlap with ``tests/test_pdf_digest.py``
+-------------------------------------------------
+That file already covers the PDF extractor + digest staging branch
+end-to-end. Here we focus on whole-cycle semantics (round-trip, dedup,
+cross-org, signed-URL bytes, permission 404, size cap) — exactly the
+surface area ``/attachments`` exposes as a contract.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+try:
+    import requests
+    _REQUESTS_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _REQUESTS_AVAILABLE = False
+
+try:
+    import psycopg
+    _PSYCOPG_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _PSYCOPG_AVAILABLE = False
+
+
+# ----------------------------------------------------------------------------
+# Configuration — worktree-specific defaults (API :8020, DB :5452)
+# ----------------------------------------------------------------------------
+
+BASE_URL = os.environ.get("CORTEX_BASE_URL", "http://localhost:8020")
+DB_DSN = os.environ.get(
+    "CORTEX_DB_DSN",
+    "postgresql://postgres:dev@localhost:5452/cortex",
+)
+
+# Admin key from db/migrations/005_seed.sql — same one used by test_pdf_digest.
+ADMIN_KEY = os.environ.get("ADMIN_KEY", "bkai_adm1_testkey_admin")
+
+# docker compose project name for this worktree (spec 0034b / Worktree Setup).
+COMPOSE_PROJECT_NAME = os.environ.get(
+    "COMPOSE_PROJECT_NAME", "brilliant-uploads"
+)
+API_SERVICE = os.environ.get("API_SERVICE", "api")
+API_CONTAINER = os.environ.get("API_CONTAINER", "brilliant-uploads-api")
+
+REQUEST_TIMEOUT = 15.0
+
+
+# ----------------------------------------------------------------------------
+# Inline fixture PDF
+# ----------------------------------------------------------------------------
+#
+# A ~460-byte pypdf-produced PDF with /Title = "Fixture Test PDF" and a
+# single blank page. Kept inline so the suite doesn't grow binary fixtures.
+# Same bytes used by test_pdf_digest — fine here; we de-duplicate by
+# appending a per-test comment after %%EOF to break sha256 uniqueness.
+
+_FIXTURE_PDF_B64 = (
+    "JVBERi0xLjMKJeLjz9MKMSAwIG9iago8PAovVHlwZSAvUGFnZXMKL0NvdW50IDEKL0tpZHMg"
+    "WyA0IDAgUiBdCj4+CmVuZG9iagoyIDAgb2JqCjw8Ci9Qcm9kdWNlciAocHlwZGYpCi9UaXRs"
+    "ZSAoRml4dHVyZVwwNDBUZXN0XDA0MFBERikKPj4KZW5kb2JqCjMgMCBvYmoKPDwKL1R5cGUg"
+    "L0NhdGFsb2cKL1BhZ2VzIDEgMCBSCj4+CmVuZG9iago0IDAgb2JqCjw8Ci9UeXBlIC9QYWdl"
+    "Ci9SZXNvdXJjZXMgPDwKPj4KL01lZGlhQm94IFsgMC4wIDAuMCAyMDAgMjAwIF0KL1BhcmVu"
+    "dCAxIDAgUgo+PgplbmRvYmoKeHJlZgowIDUKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAw"
+    "MDE1IDAwMDAwIG4gCjAwMDAwMDAwNzQgMDAwMDAgbiAKMDAwMDAwMDE0NSAwMDAwMCBuIAow"
+    "MDAwMDAwMTk0IDAwMDAwIG4gCnRyYWlsZXIKPDwKL1NpemUgNQovUm9vdCAzIDAgUgovSW5m"
+    "byAyIDAgUgo+PgpzdGFydHhyZWYKMjg4CiUlRU9GCg=="
+)
+
+
+@pytest.fixture(scope="module")
+def fixture_pdf_bytes() -> bytes:
+    return base64.b64decode(_FIXTURE_PDF_B64)
+
+
+def _unique_pdf(base: bytes) -> bytes:
+    """Return ``base`` with a random-ish tail appended after %%EOF.
+
+    pypdf stops parsing at the %%EOF marker so the suffix is ignored for
+    metadata / text purposes — but it changes the sha256, which breaks
+    per-org dedup between tests. Essential for any test that asserts
+    ``dedup=False`` on an upload.
+    """
+    suffix = f"\n% fixture-{time.time_ns()}-{uuid.uuid4().hex}\n".encode()
+    return base + suffix
+
+
+# ----------------------------------------------------------------------------
+# HTTP helpers
+# ----------------------------------------------------------------------------
+
+
+def _auth(key: str) -> dict:
+    return {"Authorization": f"Bearer {key}"}
+
+
+def _api_available() -> bool:
+    if not _REQUESTS_AVAILABLE:
+        return False
+    try:
+        return requests.get(f"{BASE_URL}/health", timeout=2.0).status_code == 200
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _REQUESTS_AVAILABLE,
+        reason="requests not installed; pip install -r tests/requirements-dev.txt",
+    ),
+    pytest.mark.skipif(
+        not _PSYCOPG_AVAILABLE,
+        reason="psycopg not installed; pip install -r tests/requirements-dev.txt",
+    ),
+    pytest.mark.skipif(
+        not _api_available(),
+        reason=f"Brilliant API not reachable at {BASE_URL} "
+        f"(start `docker compose up -d` in the uploads worktree).",
+    ),
+]
+
+
+def _upload(
+    data: bytes,
+    *,
+    key: str = ADMIN_KEY,
+    filename: str = "fixture.pdf",
+    content_type: str | None = None,
+    digest: bool = False,
+) -> requests.Response:
+    params: dict = {}
+    if digest:
+        params["digest"] = "true"
+    if content_type is not None:
+        params["content_type"] = content_type
+    multipart_ct = content_type or "application/octet-stream"
+    return requests.post(
+        f"{BASE_URL}/attachments",
+        params=params or None,
+        headers=_auth(key),
+        files={"file": (filename, data, multipart_ct)},
+        timeout=REQUEST_TIMEOUT,
+    )
+
+
+def _get(path: str, *, key: str, allow_redirects: bool = False) -> requests.Response:
+    return requests.get(
+        f"{BASE_URL}{path}",
+        headers=_auth(key),
+        timeout=REQUEST_TIMEOUT,
+        allow_redirects=allow_redirects,
+    )
+
+
+# ----------------------------------------------------------------------------
+# DB helpers — used to provision a second org + its admin API key, and to
+# clean the rows up after the test so re-runs are deterministic.
+# ----------------------------------------------------------------------------
+
+
+def _db_exec(sql: str, params: tuple | None = None) -> list[tuple]:
+    """Run a statement (superuser) and return any rows fetched."""
+    with psycopg.connect(DB_DSN, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql, params or ())
+            try:
+                return cur.fetchall()
+            except psycopg.ProgrammingError:
+                return []
+
+
+def _blob_row(blob_id: str) -> dict | None:
+    """Read a blobs row directly (bypasses RLS)."""
+    with psycopg.connect(DB_DSN, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, org_id, sha256, content_type, size_bytes,
+                       storage_backend, storage_key, uploaded_by
+                FROM blobs WHERE id = %s
+                """,
+                (blob_id,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                return None
+            cols = [c.name for c in cur.description]
+            return dict(zip(cols, row))
+
+
+# ----------------------------------------------------------------------------
+# Second-org fixture — creates org_attachtest + an admin user + bcrypt-hashed
+# API key in the DB via ``crypt()``, scoped to the test session. Teardown
+# removes everything we added so the suite is idempotent.
+# ----------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def other_org():
+    suffix = uuid.uuid4().hex[:8]
+    org_id = f"org_attachtest_{suffix}"
+    user_id = f"usr_attachtest_{suffix}"
+    # 9-char prefix: bkai_XXXX. The API's auth handler keys lookup by
+    # the first 9 chars of the token.
+    key_prefix = f"bkai_{suffix[:4]}"
+    token = f"{key_prefix}_testkey_other_{suffix}"
+
+    with psycopg.connect(DB_DSN, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO organizations (id, name, settings) "
+                "VALUES (%s, %s, '{}')",
+                (org_id, f"Attachment Test Org {suffix}"),
+            )
+            cur.execute(
+                """
+                INSERT INTO users (id, org_id, display_name, email_hash, role)
+                VALUES (%s, %s, %s,
+                        encode(digest(%s, 'sha256'), 'hex'),
+                        'admin')
+                """,
+                (user_id, org_id, f"Attach Admin {suffix}", f"{user_id}@test.local"),
+            )
+            cur.execute(
+                """
+                INSERT INTO api_keys (user_id, org_id, key_hash, key_prefix,
+                                      key_type, label)
+                VALUES (%s, %s, crypt(%s, gen_salt('bf')), %s, 'interactive',
+                        %s)
+                """,
+                (user_id, org_id, token, key_prefix, f"test-{suffix}"),
+            )
+
+    try:
+        yield {
+            "org_id": org_id,
+            "user_id": user_id,
+            "key_prefix": key_prefix,
+            "token": token,
+        }
+    finally:
+        # Tear down — children first due to FKs. Blobs / entry_attachments /
+        # staging / entries may exist depending on test flow; cascade from
+        # each.
+        with psycopg.connect(DB_DSN, autocommit=True) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM entry_attachments WHERE org_id = %s",
+                    (org_id,),
+                )
+                cur.execute("DELETE FROM staging WHERE org_id = %s", (org_id,))
+                cur.execute(
+                    "DELETE FROM entry_versions WHERE org_id = %s",
+                    (org_id,),
+                )
+                cur.execute("DELETE FROM entries WHERE org_id = %s", (org_id,))
+                cur.execute("DELETE FROM blobs WHERE org_id = %s", (org_id,))
+                cur.execute("DELETE FROM api_keys WHERE user_id = %s", (user_id,))
+                cur.execute("DELETE FROM users WHERE id = %s", (user_id,))
+                cur.execute(
+                    "DELETE FROM organizations WHERE id = %s", (org_id,)
+                )
+
+
+# ----------------------------------------------------------------------------
+# Case 1 — Upload → blobs row
+# ----------------------------------------------------------------------------
+
+
+def test_upload_creates_blob_row(fixture_pdf_bytes):
+    """Upload a small PDF; verify `blobs` row carries matching sha256 + size."""
+    payload = _unique_pdf(fixture_pdf_bytes)
+    expected_sha = hashlib.sha256(payload).hexdigest()
+
+    resp = _upload(
+        payload,
+        content_type="application/pdf",
+        filename="case1.pdf",
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+
+    assert body["sha256"] == expected_sha
+    assert body["dedup"] is False
+    assert body["size_bytes"] == len(payload)
+    assert body["content_type"] == "application/pdf"
+    assert "blob_id" in body
+
+    row = _blob_row(body["blob_id"])
+    assert row is not None, "blobs row not found via DB lookup"
+    assert row["sha256"] == expected_sha
+    assert int(row["size_bytes"]) == len(payload)
+    assert row["content_type"] == "application/pdf"
+    assert row["uploaded_by"] == "usr_admin"
+
+
+# ----------------------------------------------------------------------------
+# Case 2 — Dedup within the same org
+# ----------------------------------------------------------------------------
+
+
+def test_same_org_dedup_returns_same_blob_id(fixture_pdf_bytes):
+    """Uploading identical bytes twice within one org returns one blob_id."""
+    payload = _unique_pdf(fixture_pdf_bytes)
+
+    first = _upload(
+        payload, content_type="application/pdf", filename="dedup.pdf"
+    )
+    assert first.status_code == 201, first.text
+    first_body = first.json()
+    assert first_body["dedup"] is False
+
+    second = _upload(
+        payload, content_type="application/pdf", filename="dedup-again.pdf"
+    )
+    assert second.status_code == 201, second.text
+    second_body = second.json()
+
+    assert second_body["blob_id"] == first_body["blob_id"], (
+        "same-org dedup must return the existing blob_id"
+    )
+    assert second_body["dedup"] is True
+    assert second_body["sha256"] == first_body["sha256"]
+
+
+# ----------------------------------------------------------------------------
+# Case 3 — Cross-org isolation: distinct blob_ids + 404 on forbidden read
+# ----------------------------------------------------------------------------
+
+
+def test_cross_org_isolation_distinct_blob_ids_and_404(
+    fixture_pdf_bytes, other_org
+):
+    """Identical content uploaded by two orgs yields two blobs; each org 404s
+    when it tries to read the other's blob via GET /attachments/{blob_id}."""
+    payload = _unique_pdf(fixture_pdf_bytes)
+
+    # org_demo (ADMIN_KEY) upload.
+    r1 = _upload(
+        payload, content_type="application/pdf", filename="cross-demo.pdf"
+    )
+    assert r1.status_code == 201, r1.text
+    demo_blob_id = r1.json()["blob_id"]
+
+    # Second org upload — same bytes, different org.
+    r2 = _upload(
+        payload,
+        key=other_org["token"],
+        content_type="application/pdf",
+        filename="cross-other.pdf",
+    )
+    assert r2.status_code == 201, r2.text
+    other_blob_id = r2.json()["blob_id"]
+
+    # Distinct blob_ids — tenant isolation holds even on a shared backend.
+    assert demo_blob_id != other_blob_id, (
+        "identical content from two orgs must yield distinct blob_ids"
+    )
+
+    # DB-level check: two rows, different org_ids, same sha256.
+    demo_row = _blob_row(demo_blob_id)
+    other_row = _blob_row(other_blob_id)
+    assert demo_row is not None and other_row is not None
+    assert demo_row["org_id"] == "org_demo"
+    assert other_row["org_id"] == other_org["org_id"]
+    assert demo_row["sha256"] == other_row["sha256"]
+
+    # Forbidden reads — each side gets 404 (not 403), because neither org has
+    # any entry_attachments row referencing the other org's blob. Importantly
+    # 404, not 403, avoids leaking blob existence across tenants.
+    r_demo_reads_other = _get(f"/attachments/{other_blob_id}", key=ADMIN_KEY)
+    assert r_demo_reads_other.status_code == 404, (
+        f"expected 404 on cross-org blob read, got "
+        f"{r_demo_reads_other.status_code}: {r_demo_reads_other.text}"
+    )
+
+    r_other_reads_demo = _get(
+        f"/attachments/{demo_blob_id}", key=other_org["token"]
+    )
+    assert r_other_reads_demo.status_code == 404, (
+        f"expected 404 on cross-org blob read, got "
+        f"{r_other_reads_demo.status_code}: {r_other_reads_demo.text}"
+    )
+
+
+# ----------------------------------------------------------------------------
+# Case 4 — Digest pipeline → staging → entry → entry_attachments
+# ----------------------------------------------------------------------------
+#
+# Admin uploads via the digest endpoint; tier 1/2 auto-promotes the staging
+# row synchronously, so the resulting entry already carries the
+# entry_attachments(role='source') link on return. We then verify:
+#
+#   * staging row exists with submission_category='attachment_digest'
+#   * promoted_entry_id is populated
+#   * GET /entries/{id}/attachments returns exactly one attachment
+#     whose blob_id matches the uploaded blob
+#
+# Minimal overlap with test_pdf_digest: that file asserts the pure DB wiring;
+# here we assert the *public API* shape ``GET /entries/{id}/attachments``
+# serves the link back to its caller.
+
+
+def test_digest_to_approved_entry_attachments_round_trip(fixture_pdf_bytes):
+    payload = _unique_pdf(fixture_pdf_bytes)
+
+    resp = _upload(
+        payload,
+        content_type="application/pdf",
+        filename="digest-case4.pdf",
+        digest=True,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+
+    assert "staging_id" in body, "digest=true should return a staging_id"
+    blob_id = body["blob_id"]
+    staging_id = body["staging_id"]
+
+    # Look up the staging row to find the promoted entry id and confirm the
+    # submission_category (mirrors migration 023's expanded CHECK).
+    with psycopg.connect(DB_DSN, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT submission_category, status, promoted_entry_id
+                FROM staging WHERE id = %s
+                """,
+                (staging_id,),
+            )
+            row = cur.fetchone()
+    assert row is not None, "staging row missing"
+    category, status, promoted_entry_id = row
+    assert category == "attachment_digest"
+    # Admin via web_ui → tier 1 → auto-approved synchronously.
+    assert status == "auto_approved"
+    assert promoted_entry_id is not None, (
+        "tier 1/2 digest should auto-promote to an entry"
+    )
+    entry_id = str(promoted_entry_id)
+
+    # Public API: GET /entries/{id}/attachments returns exactly the
+    # entry_attachments row the digest pipeline created.
+    listing = _get(f"/entries/{entry_id}/attachments", key=ADMIN_KEY)
+    assert listing.status_code == 200, listing.text
+    attachments = listing.json()
+    assert isinstance(attachments, list)
+    assert len(attachments) == 1, (
+        f"expected exactly one attachment for digest entry, got: {attachments}"
+    )
+    att = attachments[0]
+    assert att["blob_id"] == blob_id
+    assert att["entry_id"] == entry_id
+    assert att["role"] == "source"
+    assert att["blob"]["sha256"] == body["sha256"]
+
+
+# ----------------------------------------------------------------------------
+# Case 5 — Signed-URL round-trip (bytes match the upload sha256)
+# ----------------------------------------------------------------------------
+
+
+def test_signed_url_round_trip_matches_upload_bytes(fixture_pdf_bytes):
+    """After digest → auto-approve, `GET /attachments/{blob_id}` issues a
+    302 to a signed URL; following it must yield bytes whose sha256 equals
+    the uploaded payload's sha256."""
+    payload = _unique_pdf(fixture_pdf_bytes)
+    expected_sha = hashlib.sha256(payload).hexdigest()
+
+    # Go through the digest pipeline so an entry_attachments row exists —
+    # that's the prerequisite for the auth check in GET /attachments/{id}.
+    up = _upload(
+        payload,
+        content_type="application/pdf",
+        filename="signed-url.pdf",
+        digest=True,
+    )
+    assert up.status_code == 201, up.text
+    blob_id = up.json()["blob_id"]
+
+    # allow_redirects=False so we inspect the 302 target explicitly.
+    redirect = _get(f"/attachments/{blob_id}", key=ADMIN_KEY)
+    assert redirect.status_code == 302, (
+        f"expected 302 redirect, got {redirect.status_code}: {redirect.text}"
+    )
+    location = redirect.headers.get("Location")
+    assert location, "302 response missing Location header"
+
+    # Normalize: the LocalStorage signer returns a relative URL
+    # (/attachments/_local/...). S3Storage would return an absolute URL —
+    # support both shapes.
+    if location.startswith("/"):
+        signed_url = f"{BASE_URL}{location}"
+    else:
+        signed_url = location
+
+    # Signed URL is a bearer token on its own — no auth header needed.
+    fetched = requests.get(signed_url, timeout=REQUEST_TIMEOUT)
+    assert fetched.status_code == 200, fetched.text
+    assert hashlib.sha256(fetched.content).hexdigest() == expected_sha, (
+        "signed-URL-served bytes do not match uploaded sha256"
+    )
+    # Bonus: verify content-type was preserved through the pipeline.
+    assert fetched.headers.get("Content-Type", "").startswith(
+        "application/pdf"
+    )
+
+
+# ----------------------------------------------------------------------------
+# Case 6 — Permission 404 (not 403) on a forbidden blob_id
+# ----------------------------------------------------------------------------
+#
+# We upload a blob WITHOUT digesting it (so no entry_attachments row is
+# created). Any user — including the owner — requesting
+# GET /attachments/{blob_id} must get 404, because the endpoint's access
+# check requires at least one visible entry_attachments row linking the
+# caller to the blob. The point: the response must be 404 (don't leak
+# existence), not 403 (which would tell a probe the blob exists).
+
+
+def test_attachment_without_entry_link_returns_404_not_403(fixture_pdf_bytes):
+    payload = _unique_pdf(fixture_pdf_bytes)
+    up = _upload(
+        payload, content_type="application/pdf", filename="no-link.pdf"
+    )
+    assert up.status_code == 201, up.text
+    blob_id = up.json()["blob_id"]
+
+    # Sanity: the blobs row actually exists.
+    assert _blob_row(blob_id) is not None
+
+    # No entry_attachments row → 404 for the owner too.
+    resp = _get(f"/attachments/{blob_id}", key=ADMIN_KEY)
+    assert resp.status_code == 404, (
+        f"expected 404 on blob with no entry link, got "
+        f"{resp.status_code}: {resp.text}"
+    )
+
+
+def test_attachment_cross_org_with_entry_link_still_404(
+    fixture_pdf_bytes, other_org
+):
+    """Even a blob with a valid entry_attachments link is 404 to an outside
+    org: the cross-org request can't see the owning entry via RLS, so the
+    auth probe finds zero rows and answers 404 (not 403)."""
+    payload = _unique_pdf(fixture_pdf_bytes)
+    # org_demo runs the full digest → entry_attachments pipeline so a link
+    # exists — this exercises the more-interesting 404 path where a blob
+    # DOES have a link but the caller can't see it.
+    up = _upload(
+        payload,
+        content_type="application/pdf",
+        filename="link-hidden.pdf",
+        digest=True,
+    )
+    assert up.status_code == 201, up.text
+    blob_id = up.json()["blob_id"]
+
+    # Owner can see it — establish the positive control.
+    assert _get(f"/attachments/{blob_id}", key=ADMIN_KEY).status_code == 302
+
+    # Different org reads it — 404, not 403.
+    resp = _get(f"/attachments/{blob_id}", key=other_org["token"])
+    assert resp.status_code == 404, (
+        f"cross-org blob read must be 404 (not 403) to avoid leaking "
+        f"existence; got {resp.status_code}: {resp.text}"
+    )
+
+
+# ----------------------------------------------------------------------------
+# Case 7 — Over-size 413
+# ----------------------------------------------------------------------------
+#
+# The endpoint reads MAX_ATTACHMENT_BYTES from os.environ on each request,
+# so to exercise the 413 path without having to push 50+ MiB we need to
+# restart the API container with a small cap. The fixture below does so via
+# ``docker compose up -d api`` with an injected override file, and restores
+# the pre-test state on teardown.
+#
+# If docker/compose isn't available the test is skipped with a clear
+# message; otherwise the test runs deterministically.
+
+_SMALL_MAX = 1024  # 1 KiB — tiny enough that any non-trivial payload overruns.
+
+# Per-test override file name. Dropped next to the worktree's compose files
+# and merged in via `docker compose -f ... -f ...` so we never mutate the
+# committed / user-curated docker-compose.override.yml contents.
+_TEST_OVERRIDE_FILENAME = "docker-compose.test-413.yml"
+
+
+def _compose_available() -> bool:
+    try:
+        r = subprocess.run(
+            ["docker", "compose", "version"],
+            check=False,
+            capture_output=True,
+            timeout=5,
+        )
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def _wait_for_api(timeout: float = 30.0) -> bool:
+    """Poll /health until the API is responsive again after a restart."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            if requests.get(f"{BASE_URL}/health", timeout=2.0).status_code == 200:
+                return True
+        except Exception:
+            pass
+        time.sleep(0.5)
+    return False
+
+
+def _compose_files() -> list[str]:
+    """Compose file list mirroring the default resolution order.
+
+    docker compose picks up ``docker-compose.yml`` + ``docker-compose.override.yml``
+    by default. We must pass both explicitly when adding a third file
+    because supplying `-f` disables the implicit lookup.
+    """
+    base = _REPO_ROOT / "docker-compose.yml"
+    override = _REPO_ROOT / "docker-compose.override.yml"
+    files = ["-f", str(base)]
+    if override.exists():
+        files += ["-f", str(override)]
+    return files
+
+
+@pytest.fixture
+def api_with_small_max_bytes():
+    """Temporarily restart the API container with MAX_ATTACHMENT_BYTES=1024.
+
+    Writes a dedicated ``docker-compose.test-413.yml`` next to the
+    worktree's compose files, passes it to ``docker compose up -d api``
+    alongside the base + worktree override files, and removes it +
+    recreates the container with the baseline config on teardown.
+
+    Using a dedicated override file (rather than mutating the checked-in
+    one) means the test leaves no footprint on the repo's normal compose
+    state if it crashes mid-run.
+    """
+    if not _compose_available():
+        pytest.skip("`docker compose` CLI not available; cannot exercise 413 path")
+
+    override_path = _REPO_ROOT / _TEST_OVERRIDE_FILENAME
+    override_path.write_text(_build_test_override(_SMALL_MAX))
+
+    env = {**os.environ, "COMPOSE_PROJECT_NAME": COMPOSE_PROJECT_NAME}
+    compose_files = _compose_files() + ["-f", str(override_path)]
+
+    def _up(extra_files: list[str]) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["docker", "compose", *extra_files, "up", "-d", API_SERVICE],
+            cwd=str(_REPO_ROOT),
+            env=env,
+            check=True,
+            capture_output=True,
+            timeout=60,
+        )
+
+    try:
+        _up(compose_files)
+        if not _wait_for_api(timeout=30):
+            pytest.fail("API failed to come back up after override restart")
+        yield _SMALL_MAX
+    finally:
+        # Drop the override file first so any recreate goes back to baseline.
+        try:
+            override_path.unlink()
+        except FileNotFoundError:
+            pass
+        # Recreate once more without the test override to drop the cap.
+        try:
+            _up(_compose_files())
+            _wait_for_api(timeout=30)
+        except Exception as e:  # pragma: no cover — teardown best-effort
+            sys.stderr.write(
+                f"WARNING: failed to restore API after 413 test: {e}\n"
+            )
+
+
+def _build_test_override(max_bytes: int) -> str:
+    """Produce the merge-overlay YAML setting MAX_ATTACHMENT_BYTES on api.
+
+    Compose merges ``environment:`` mappings across override files, so
+    this only needs to supply the delta — existing env vars
+    (DATABASE_URL, etc.) are preserved from the base file.
+    """
+    return (
+        "# Auto-written by tests/test_attachments.py::api_with_small_max_bytes.\n"
+        "# Safe to delete — regenerated on demand.\n"
+        "services:\n"
+        "  api:\n"
+        "    environment:\n"
+        f"      MAX_ATTACHMENT_BYTES: \"{max_bytes}\"\n"
+    )
+
+
+def test_oversize_upload_returns_413(api_with_small_max_bytes):
+    """With MAX_ATTACHMENT_BYTES set small, a larger upload must 413."""
+    small_max = api_with_small_max_bytes
+    # 2 * the cap, random-ish content type -- size is what matters.
+    payload = b"X" * (small_max * 2)
+
+    resp = _upload(
+        payload,
+        content_type="application/octet-stream",
+        filename="big.bin",
+    )
+    assert resp.status_code == 413, (
+        f"expected 413 for oversize upload, got {resp.status_code}: {resp.text}"
+    )
+    # Error detail should mention the cap.
+    try:
+        detail = resp.json().get("detail", "")
+    except Exception:
+        detail = resp.text
+    assert str(small_max) in detail or "MAX_ATTACHMENT_BYTES" in detail
+
+
+def test_within_cap_after_restart_still_uploads(api_with_small_max_bytes):
+    """Sanity: with the small cap in place, a tiny payload still succeeds.
+
+    Ensures the 413 test's assertion isn't just tripping a generic 5xx from
+    a broken restart. Also verifies the env override is actually active
+    (a tiny upload under the cap would always succeed regardless).
+    """
+    # Under the small cap (1 KiB), a 100-byte payload still uploads cleanly.
+    tiny = b"ok" * 50
+    resp = _upload(
+        tiny,
+        content_type="application/octet-stream",
+        filename="tiny.bin",
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["size_bytes"] == len(tiny)

--- a/tests/test_pdf_digest.py
+++ b/tests/test_pdf_digest.py
@@ -1,0 +1,329 @@
+"""Tests for the PDF digest pipeline (spec 0034b, T-0183).
+
+Exercises `POST /attachments?digest=true&content_type=application/pdf`
+end-to-end against a live API:
+
+* Upload a tiny valid PDF → staging row created + `staging_id` in response.
+* Non-PDF content or `digest=false` → no staging row created.
+* Corrupt PDF bytes → staging row still created (empty content), no 500.
+* Tier 1/2 auto-approval produces an `entry_attachments(role='source')`
+  row linking the promoted entry back to the original blob.
+
+Also exercises `api/services/pdf_extract.py` in isolation with in-process
+`pypdf` round-trips (no API / DB required) so the extractor's contract
+is covered even if the integration tests are skipped.
+
+Prerequisites for the integration path:
+  1. `docker compose up -d --build`  (API on :8020 in this worktree)
+  2. `pip install -r tests/requirements-dev.txt`
+  3. Migration 023 applied (expands submission_category CHECK).
+
+Run:
+  pytest tests/test_pdf_digest.py -v
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+# --- Import the pure-python extractor without requiring a running stack -----
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_API_DIR = _REPO_ROOT / "api"
+if str(_API_DIR) not in sys.path:
+    sys.path.insert(0, str(_API_DIR))
+
+
+try:
+    from services.pdf_extract import extract_pdf  # noqa: E402
+    # The extractor is tolerant of missing pypdf (returns empty tuples);
+    # but the unit tests here assert actual parsing, so we require pypdf
+    # on the host Python as well.
+    import pypdf  # noqa: F401 — availability check only
+    _EXTRACT_AVAILABLE = True
+except Exception:  # pragma: no cover
+    _EXTRACT_AVAILABLE = False
+
+try:
+    import requests  # noqa: E402
+    _REQUESTS_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _REQUESTS_AVAILABLE = False
+
+try:
+    import psycopg  # noqa: E402
+    _PSYCOPG_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _PSYCOPG_AVAILABLE = False
+
+
+BASE_URL = os.environ.get("CORTEX_BASE_URL", "http://localhost:8020")
+DB_DSN = os.environ.get(
+    "CORTEX_DB_DSN",
+    "postgresql://postgres:dev@localhost:5452/cortex",
+)
+ADMIN_KEY = os.environ.get("ADMIN_KEY", "bkai_adm1_testkey_admin")
+
+
+# ----------------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------------
+
+
+# Tiny pypdf-generated PDF with /Title = "Fixture Test PDF" — blank page,
+# 463 bytes. Kept inline so the test suite doesn't grow binary fixtures.
+_FIXTURE_PDF_B64 = (
+    "JVBERi0xLjMKJeLjz9MKMSAwIG9iago8PAovVHlwZSAvUGFnZXMKL0NvdW50IDEKL0tpZHMg"
+    "WyA0IDAgUiBdCj4+CmVuZG9iagoyIDAgb2JqCjw8Ci9Qcm9kdWNlciAocHlwZGYpCi9UaXRs"
+    "ZSAoRml4dHVyZVwwNDBUZXN0XDA0MFBERikKPj4KZW5kb2JqCjMgMCBvYmoKPDwKL1R5cGUg"
+    "L0NhdGFsb2cKL1BhZ2VzIDEgMCBSCj4+CmVuZG9iago0IDAgb2JqCjw8Ci9UeXBlIC9QYWdl"
+    "Ci9SZXNvdXJjZXMgPDwKPj4KL01lZGlhQm94IFsgMC4wIDAuMCAyMDAgMjAwIF0KL1BhcmVu"
+    "dCAxIDAgUgo+PgplbmRvYmoKeHJlZgowIDUKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAw"
+    "MDE1IDAwMDAwIG4gCjAwMDAwMDAwNzQgMDAwMDAgbiAKMDAwMDAwMDE0NSAwMDAwMCBuIAow"
+    "MDAwMDAwMTk0IDAwMDAwIG4gCnRyYWlsZXIKPDwKL1NpemUgNQovUm9vdCAzIDAgUgovSW5m"
+    "byAyIDAgUgo+PgpzdGFydHhyZWYKMjg4CiUlRU9GCg=="
+)
+
+
+@pytest.fixture(scope="module")
+def fixture_pdf_bytes() -> bytes:
+    return base64.b64decode(_FIXTURE_PDF_B64)
+
+
+def _api_available() -> bool:
+    try:
+        return requests.get(f"{BASE_URL}/health", timeout=2.0).status_code == 200
+    except Exception:
+        return False
+
+
+_INTEGRATION_GUARDS = [
+    pytest.mark.skipif(
+        not _REQUESTS_AVAILABLE,
+        reason="requests not installed; install tests/requirements-dev.txt",
+    ),
+    pytest.mark.skipif(
+        not _api_available(),
+        reason=f"Brilliant API not reachable at {BASE_URL} — start docker compose up -d.",
+    ),
+    pytest.mark.skipif(
+        not _PSYCOPG_AVAILABLE,
+        reason="psycopg not installed; cannot verify DB rows",
+    ),
+]
+
+
+def _headers() -> dict:
+    return {"Authorization": f"Bearer {ADMIN_KEY}"}
+
+
+def _unique_bytes(base: bytes) -> bytes:
+    """Return a copy of `base` with a random-ish suffix so sha256 is unique.
+
+    Appending bytes after `%%EOF` is a no-op for pypdf (EOF marker ends the
+    stream), so this preserves PDF validity while breaking dedup across
+    tests.
+    """
+    suffix = f"\n% fixture-{time.time_ns()}-{os.getpid()}\n".encode()
+    return base + suffix
+
+
+# ----------------------------------------------------------------------------
+# Pure-python extractor tests (no API / DB needed)
+# ----------------------------------------------------------------------------
+
+
+_extract_skip = pytest.mark.skipif(
+    not _EXTRACT_AVAILABLE,
+    reason="services.pdf_extract not importable",
+)
+
+
+@_extract_skip
+def test_extract_pdf_uses_metadata_title(fixture_pdf_bytes):
+    title, text = extract_pdf(fixture_pdf_bytes, filename="irrelevant.pdf")
+    assert title == "Fixture Test PDF"
+    # Blank page → no extractable text.
+    assert text == ""
+
+
+@_extract_skip
+def test_extract_pdf_filename_fallback_on_empty_bytes():
+    title, text = extract_pdf(b"", filename="My Doc.pdf")
+    assert title == "My Doc"
+    assert text == ""
+
+
+@_extract_skip
+def test_extract_pdf_returns_empty_on_corrupt_bytes():
+    title, text = extract_pdf(b"not a pdf at all", filename="nope.pdf")
+    assert title == ""
+    assert text == ""
+
+
+@_extract_skip
+def test_extract_pdf_filename_strips_pdf_extension():
+    title, text = extract_pdf(b"", filename="/tmp/path/to/report.PDF")
+    assert title == "report"
+    assert text == ""
+
+
+# ----------------------------------------------------------------------------
+# Integration tests against a live API + DB
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("_api_guard")
+def test_digest_true_pdf_creates_staging_row(fixture_pdf_bytes):
+    """Happy path: PDF + digest=true → staging row with staging_id + auto_approved."""
+    pdf = _unique_bytes(fixture_pdf_bytes)
+    resp = requests.post(
+        f"{BASE_URL}/attachments",
+        params={"digest": "true", "content_type": "application/pdf"},
+        headers=_headers(),
+        files={"file": ("fixture.pdf", pdf, "application/pdf")},
+        timeout=10,
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert "staging_id" in body
+    assert body["content_type"] == "application/pdf"
+    assert body["size_bytes"] == len(pdf)
+
+    with psycopg.connect(DB_DSN) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT submission_category, change_type, proposed_title, status, promoted_entry_id "
+                "FROM staging WHERE id = %s",
+                (body["staging_id"],),
+            )
+            row = cur.fetchone()
+    assert row is not None
+    category, change_type, title, status, promoted_entry_id = row
+    assert category == "attachment_digest"
+    assert change_type == "create"
+    assert title == "Fixture Test PDF"
+    # Tier 1/2 auto-approves synchronously.
+    assert status == "auto_approved"
+    assert promoted_entry_id is not None
+
+
+@pytest.mark.usefixtures("_api_guard")
+def test_auto_approved_digest_creates_entry_attachments_row(fixture_pdf_bytes):
+    """After Tier 1/2 auto-approve, entry_attachments(role='source') is populated."""
+    pdf = _unique_bytes(fixture_pdf_bytes)
+    resp = requests.post(
+        f"{BASE_URL}/attachments",
+        params={"digest": "true", "content_type": "application/pdf"},
+        headers=_headers(),
+        files={"file": ("fixture.pdf", pdf, "application/pdf")},
+        timeout=10,
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    blob_id = body["blob_id"]
+    staging_id = body["staging_id"]
+
+    with psycopg.connect(DB_DSN) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT promoted_entry_id FROM staging WHERE id = %s",
+                (staging_id,),
+            )
+            (entry_id,) = cur.fetchone()
+            assert entry_id is not None
+
+            cur.execute(
+                "SELECT role FROM entry_attachments "
+                "WHERE entry_id = %s AND blob_id = %s",
+                (entry_id, blob_id),
+            )
+            row = cur.fetchone()
+    assert row is not None, "entry_attachments row missing"
+    assert row[0] == "source"
+
+
+@pytest.mark.usefixtures("_api_guard")
+def test_digest_false_does_not_create_staging(fixture_pdf_bytes):
+    pdf = _unique_bytes(fixture_pdf_bytes)
+    # digest not set → defaults to false
+    resp = requests.post(
+        f"{BASE_URL}/attachments",
+        headers=_headers(),
+        files={"file": ("no-digest.pdf", pdf, "application/pdf")},
+        timeout=10,
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert "staging_id" not in body
+    # Content-type in response matches the multipart header.
+    assert body["content_type"] == "application/pdf"
+
+
+@pytest.mark.usefixtures("_api_guard")
+def test_non_pdf_with_digest_true_does_not_create_staging():
+    """digest=true + non-PDF content type → no staging row (silent fallthrough)."""
+    payload = b"hello world text\n"
+    resp = requests.post(
+        f"{BASE_URL}/attachments",
+        params={"digest": "true", "content_type": "text/plain"},
+        headers=_headers(),
+        files={"file": ("hello.txt", payload, "text/plain")},
+        timeout=10,
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert "staging_id" not in body
+
+
+@pytest.mark.usefixtures("_api_guard")
+def test_corrupt_pdf_still_creates_staging_row():
+    """Corrupt bytes shouldn't 500 — we stage with empty content instead."""
+    corrupt = b"%PDF-1.4\nthis is not really a pdf\n%%EOF\n" + os.urandom(8)
+    resp = requests.post(
+        f"{BASE_URL}/attachments",
+        params={"digest": "true", "content_type": "application/pdf"},
+        headers=_headers(),
+        files={"file": ("corrupt.pdf", corrupt, "application/pdf")},
+        timeout=10,
+    )
+    # The upload path succeeds; extraction failure is absorbed.
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert "staging_id" in body
+
+    with psycopg.connect(DB_DSN) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT proposed_content, proposed_title "
+                "FROM staging WHERE id = %s",
+                (body["staging_id"],),
+            )
+            content, title = cur.fetchone()
+    # Empty extracted text; title falls back to filename ("corrupt").
+    assert content == ""
+    assert title == "corrupt"
+
+
+# ----------------------------------------------------------------------------
+# Guard fixture — applied per-integration-test via usefixtures
+# ----------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _api_guard():
+    """Apply the stacked skip guards to each integration test."""
+    if not _REQUESTS_AVAILABLE:
+        pytest.skip("requests not installed; install tests/requirements-dev.txt")
+    if not _PSYCOPG_AVAILABLE:
+        pytest.skip("psycopg not installed; cannot verify DB rows")
+    if not _api_available():
+        pytest.skip(f"Brilliant API not reachable at {BASE_URL}")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,280 @@
+"""Unit tests for the blob storage abstraction (spec 0034b, T-0181).
+
+Covers `api/services/storage.py`:
+
+* Round-trip a 1 MiB payload through `LocalStorage` (put → get → delete)
+  and verify the SHA-256 matches end to end.
+* Verify that signed URLs produced by `LocalStorage.signed_url` are
+  accepted by `verify_local_signed_url` within the TTL window.
+* Verify that expired signatures are rejected.
+* Verify that tampered signatures / keys / expirations are rejected.
+* Verify that `get_storage()` honors `STORAGE_BACKEND=local`.
+* Skip the S3 path unless `S3_BUCKET` is set (no network required).
+
+Run:
+    pytest tests/test_storage.py -q
+
+The tests write to an isolated temp directory, so they don't pollute
+`/data/uploads` and don't require the docker stack to be up.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+# Make `api/` importable so `api.services.storage` resolves when running
+# pytest from the repo root (and mirror how the api container imports).
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_API_DIR = _REPO_ROOT / "api"
+if str(_API_DIR) not in sys.path:
+    sys.path.insert(0, str(_API_DIR))
+
+
+@pytest.fixture
+def storage_env(tmp_path, monkeypatch):
+    """Isolate storage env vars and caches to a per-test tmp directory."""
+    # Fresh root + deterministic signing key for reproducibility.
+    root = tmp_path / "uploads"
+    root.mkdir()
+    monkeypatch.setenv("LOCAL_STORAGE_ROOT", str(root))
+    monkeypatch.setenv("STORAGE_BACKEND", "local")
+    monkeypatch.setenv("LOCAL_STORAGE_SIGNING_KEY", "00" * 32)
+
+    # Reload the module so the cached singleton (if any) is cleared and
+    # env vars are re-read at construction time.
+    if "services.storage" in sys.modules:
+        storage_mod = importlib.reload(sys.modules["services.storage"])
+    else:
+        storage_mod = importlib.import_module("services.storage")
+    storage_mod._reset_storage_singleton_for_tests()
+    yield storage_mod, root
+    storage_mod._reset_storage_singleton_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# LocalStorage round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_local_storage_round_trip_1mib(storage_env):
+    """1 MiB payload survives put → get and SHA-256 is preserved."""
+    storage_mod, root = storage_env
+    storage = storage_mod.LocalStorage()
+
+    payload = os.urandom(1024 * 1024)  # 1 MiB
+    sha = hashlib.sha256(payload).hexdigest()
+    org_id = "00000000-0000-0000-0000-000000000001"
+
+    import asyncio
+
+    async def _run():
+        key = await storage.put(org_id, sha, "application/octet-stream", payload)
+        assert key == f"{org_id}/{sha[:2]}/{sha}"
+        # File on disk at the expected path.
+        disk_path = root / org_id / sha[:2] / sha
+        assert disk_path.exists()
+        assert disk_path.stat().st_size == len(payload)
+
+        got = await storage.get(key)
+        assert got == payload
+        assert hashlib.sha256(got).hexdigest() == sha
+
+        await storage.delete(key)
+        assert not disk_path.exists()
+
+        # Delete is idempotent.
+        await storage.delete(key)
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Signed-URL validity
+# ---------------------------------------------------------------------------
+
+
+def test_signed_url_valid_within_ttl(storage_env):
+    storage_mod, _root = storage_env
+    storage = storage_mod.LocalStorage()
+
+    key = "org/ab/abc123"
+    url = storage.signed_url(key, ttl_seconds=60)
+
+    # URL embeds the key and the exp/sig query string.
+    assert "/attachments/_local/" in url
+    assert "exp=" in url and "sig=" in url
+
+    exp = int(_query_param(url, "exp"))
+    sig = _query_param(url, "sig")
+
+    assert storage_mod.verify_local_signed_url(key, exp, sig) is True
+
+
+def test_signed_url_expired(storage_env):
+    """An expired exp should be rejected."""
+    storage_mod, _root = storage_env
+    storage = storage_mod.LocalStorage()
+
+    key = "org/cd/def456"
+    # Manually construct a URL with an exp in the past using the same
+    # signing path the class uses. We use the class's private helpers
+    # via the public signed_url + overriding time is simpler:
+    past_exp = int(time.time()) - 10
+    sig_past = _sign_like(storage, key, past_exp)
+
+    assert storage_mod.verify_local_signed_url(key, past_exp, sig_past) is False
+
+
+def test_signed_url_tampered_signature(storage_env):
+    """Any bit-flip in the signature must be rejected."""
+    storage_mod, _root = storage_env
+    storage = storage_mod.LocalStorage()
+
+    key = "org/ef/ghi789"
+    url = storage.signed_url(key, ttl_seconds=60)
+    exp = int(_query_param(url, "exp"))
+    sig = _query_param(url, "sig")
+
+    # Flip one hex character in the signature.
+    bad_char = "0" if sig[0] != "0" else "1"
+    tampered = bad_char + sig[1:]
+    assert tampered != sig
+
+    assert storage_mod.verify_local_signed_url(key, exp, tampered) is False
+
+
+def test_signed_url_tampered_key(storage_env):
+    """Signature bound to a different key must not verify under another key."""
+    storage_mod, _root = storage_env
+    storage = storage_mod.LocalStorage()
+
+    key_a = "org/aa/aaa"
+    key_b = "org/bb/bbb"
+    url = storage.signed_url(key_a, ttl_seconds=60)
+    exp = int(_query_param(url, "exp"))
+    sig = _query_param(url, "sig")
+
+    assert storage_mod.verify_local_signed_url(key_b, exp, sig) is False
+
+
+def test_signed_url_tampered_exp(storage_env):
+    """Extending the exp invalidates the signature."""
+    storage_mod, _root = storage_env
+    storage = storage_mod.LocalStorage()
+
+    key = "org/zz/zzz"
+    url = storage.signed_url(key, ttl_seconds=60)
+    exp = int(_query_param(url, "exp"))
+    sig = _query_param(url, "sig")
+
+    assert storage_mod.verify_local_signed_url(key, exp + 3600, sig) is False
+
+
+def test_signed_url_malformed_exp(storage_env):
+    storage_mod, _root = storage_env
+    storage = storage_mod.LocalStorage()
+
+    key = "org/mm/mmm"
+    url = storage.signed_url(key, ttl_seconds=60)
+    sig = _query_param(url, "sig")
+
+    assert storage_mod.verify_local_signed_url(key, "not-a-number", sig) is False
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+
+def test_get_storage_local_default(storage_env):
+    storage_mod, _root = storage_env
+    instance = storage_mod.get_storage()
+    assert isinstance(instance, storage_mod.LocalStorage)
+
+    # Second call returns the same singleton.
+    assert storage_mod.get_storage() is instance
+
+
+def test_get_storage_rejects_unknown_backend(storage_env, monkeypatch):
+    storage_mod, _root = storage_env
+    storage_mod._reset_storage_singleton_for_tests()
+    monkeypatch.setenv("STORAGE_BACKEND", "nope")
+    with pytest.raises(RuntimeError):
+        storage_mod.get_storage()
+
+
+def test_module_imports_without_boto3(storage_env):
+    """Importing the module must not require boto3 at module load time."""
+    storage_mod, _root = storage_env
+    # Simply re-import and assert the relevant names exist; the fixture
+    # already performed the reload. If boto3 were imported at module
+    # scope, an environment without it would fail before this assertion.
+    for name in ("Storage", "LocalStorage", "S3Storage", "get_storage"):
+        assert hasattr(storage_mod, name), f"missing export: {name}"
+
+
+# ---------------------------------------------------------------------------
+# S3 path — skipped unless S3_BUCKET is set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get("S3_BUCKET"),
+    reason="S3_BUCKET not set — skipping S3 round-trip (no network in CI)",
+)
+def test_s3_storage_round_trip(storage_env):  # pragma: no cover — opt-in only
+    import asyncio
+
+    storage_mod, _root = storage_env
+    storage = storage_mod.S3Storage()
+
+    payload = os.urandom(1024)
+    sha = hashlib.sha256(payload).hexdigest()
+    org_id = "00000000-0000-0000-0000-000000000099"
+
+    async def _run():
+        key = await storage.put(org_id, sha, "application/octet-stream", payload)
+        got = await storage.get(key)
+        assert got == payload
+        await storage.delete(key)
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _query_param(url: str, name: str) -> str:
+    from urllib.parse import urlparse, parse_qs
+
+    qs = parse_qs(urlparse(url).query)
+    vals = qs.get(name)
+    if not vals:
+        raise AssertionError(f"missing query param {name!r} in {url}")
+    return vals[0]
+
+
+def _sign_like(storage, key: str, exp: int) -> str:
+    """Sign a payload using the storage instance's HMAC key.
+
+    Accesses `_signing_key` directly so tests can construct adversarial
+    URLs (expired, tampered) without duplicating the sign logic.
+    """
+    import hmac as _hmac
+    import hashlib as _hashlib
+
+    return _hmac.new(
+        storage._signing_key,
+        f"{key}:{exp}".encode("utf-8"),
+        _hashlib.sha256,
+    ).hexdigest()

--- a/tests/validate_schema.sql
+++ b/tests/validate_schema.sql
@@ -235,4 +235,202 @@ BEGIN
 END;
 $$;
 
+-- =============================================================================
+-- TEST 7: Blobs + entry_attachments — 2-org isolation (migration 022)
+--
+-- Insert an org_alpha organization/user, insert a blob + attachment there,
+-- and verify org_demo callers see zero rows. Also verify that the same sha256
+-- can coexist across orgs (per-org UNIQUE, not global UNIQUE).
+-- =============================================================================
+
+-- Setup: a second org with one admin user, run as superuser (bypasses RLS
+-- for seed inserts only). The API never does this at runtime.
+DO $$
+BEGIN
+    INSERT INTO organizations (id, name, settings) VALUES
+        ('org_alpha', 'Alpha Org (validation)', '{}')
+    ON CONFLICT (id) DO NOTHING;
+
+    INSERT INTO users (id, org_id, display_name, email_hash, role, department)
+    VALUES (
+        'usr_alpha_admin', 'org_alpha', 'Alpha Admin',
+        encode(digest('alpha-admin@alpha.org', 'sha256'), 'hex'),
+        'admin', 'leadership'
+    ) ON CONFLICT (id) DO NOTHING;
+
+    INSERT INTO users (id, org_id, display_name, email_hash, role, department)
+    VALUES (
+        'usr_demo_uploader', 'org_demo', 'Demo Uploader',
+        encode(digest('uploader@demo.org', 'sha256'), 'hex'),
+        'admin', 'leadership'
+    ) ON CONFLICT (id) DO NOTHING;
+END;
+$$;
+
+-- Insert a blob + attachment in org_alpha as kb_admin@org_alpha.
+DO $$
+DECLARE
+    alpha_blob_id UUID;
+    alpha_entry_id UUID;
+    alpha_attachment_id UUID;
+BEGIN
+    SET LOCAL ROLE kb_admin;
+    SET LOCAL app.user_id = 'usr_alpha_admin';
+    SET LOCAL app.org_id = 'org_alpha';
+    SET LOCAL app.role = 'admin';
+    SET LOCAL app.department = 'leadership';
+
+    -- Need an entry in org_alpha to attach to.
+    INSERT INTO entries (
+        org_id, title, content, content_hash, content_type, logical_path,
+        sensitivity, created_by, updated_by, source
+    ) VALUES (
+        'org_alpha', 'Alpha Entry', 'Alpha content',
+        md5('Alpha content'), 'context', 'Test/alpha-attach',
+        'shared', 'usr_alpha_admin', 'usr_alpha_admin', 'web_ui'
+    ) RETURNING id INTO alpha_entry_id;
+
+    INSERT INTO blobs (
+        org_id, sha256, content_type, size_bytes,
+        storage_backend, storage_key, uploaded_by
+    ) VALUES (
+        'org_alpha',
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        'application/pdf', 1024, 'local',
+        'org_alpha/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        'usr_alpha_admin'
+    ) RETURNING id INTO alpha_blob_id;
+
+    INSERT INTO entry_attachments (org_id, entry_id, blob_id, role)
+    VALUES ('org_alpha', alpha_entry_id, alpha_blob_id, 'source')
+    RETURNING id INTO alpha_attachment_id;
+
+    IF alpha_blob_id IS NOT NULL AND alpha_attachment_id IS NOT NULL THEN
+        RAISE NOTICE 'PASS: org_alpha seeded blob % and attachment %', alpha_blob_id, alpha_attachment_id;
+    END IF;
+
+    RESET ROLE;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE NOTICE 'FAIL: org_alpha blob/attachment seed failed: %', SQLERRM;
+        RESET ROLE;
+END;
+$$;
+
+-- Verify org_demo admin cannot see any org_alpha blobs or attachments.
+DO $$
+DECLARE
+    cross_blob_count INTEGER;
+    cross_att_count  INTEGER;
+BEGIN
+    SET LOCAL ROLE kb_admin;
+    SET LOCAL app.user_id = 'usr_admin';
+    SET LOCAL app.org_id = 'org_demo';
+    SET LOCAL app.role = 'admin';
+    SET LOCAL app.department = 'leadership';
+
+    SELECT count(*) INTO cross_blob_count
+    FROM blobs WHERE org_id = 'org_alpha';
+
+    SELECT count(*) INTO cross_att_count
+    FROM entry_attachments WHERE org_id = 'org_alpha';
+
+    IF cross_blob_count = 0 AND cross_att_count = 0 THEN
+        RAISE NOTICE 'PASS: org_demo sees 0 org_alpha blobs and 0 org_alpha attachments (cross-org isolation)';
+    ELSE
+        RAISE NOTICE 'FAIL: cross-org leak — org_demo sees % blobs and % attachments from org_alpha',
+            cross_blob_count, cross_att_count;
+    END IF;
+
+    RESET ROLE;
+END;
+$$;
+
+-- Verify that the same sha256 can exist in a different org (per-org UNIQUE,
+-- not global). Insert identical content in org_demo and confirm it gets a
+-- distinct blob_id.
+DO $$
+DECLARE
+    demo_blob_id UUID;
+    total_with_sha INTEGER;
+BEGIN
+    SET LOCAL ROLE kb_admin;
+    SET LOCAL app.user_id = 'usr_demo_uploader';
+    SET LOCAL app.org_id = 'org_demo';
+    SET LOCAL app.role = 'admin';
+    SET LOCAL app.department = 'leadership';
+
+    INSERT INTO blobs (
+        org_id, sha256, content_type, size_bytes,
+        storage_backend, storage_key, uploaded_by
+    ) VALUES (
+        'org_demo',
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        'application/pdf', 1024, 'local',
+        'org_demo/aa/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        'usr_demo_uploader'
+    ) RETURNING id INTO demo_blob_id;
+
+    -- Superuser-style global count: switch to admin on org_alpha AND verify
+    -- it still sees exactly one row (its own), proving isolation holds
+    -- symmetrically.
+    RESET ROLE;
+    SET LOCAL ROLE kb_admin;
+    SET LOCAL app.user_id = 'usr_alpha_admin';
+    SET LOCAL app.org_id = 'org_alpha';
+    SET LOCAL app.role = 'admin';
+    SET LOCAL app.department = 'leadership';
+
+    SELECT count(*) INTO total_with_sha
+    FROM blobs
+    WHERE sha256 = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    -- org_alpha admin sees only its own row despite matching sha256 in org_demo
+    IF total_with_sha = 1 THEN
+        RAISE NOTICE 'PASS: identical sha256 across orgs yields distinct rows visible only within their org';
+    ELSE
+        RAISE NOTICE 'FAIL: org_alpha admin sees % rows for shared sha256 (expected 1)', total_with_sha;
+    END IF;
+
+    RESET ROLE;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE NOTICE 'FAIL: cross-org sha256 test failed: %', SQLERRM;
+        RESET ROLE;
+END;
+$$;
+
+-- Clean up org_alpha fixtures so a re-run of this script stays idempotent-ish.
+DO $$
+BEGIN
+    SET LOCAL ROLE kb_admin;
+    SET LOCAL app.user_id = 'usr_alpha_admin';
+    SET LOCAL app.org_id = 'org_alpha';
+    SET LOCAL app.role = 'admin';
+    SET LOCAL app.department = 'leadership';
+
+    DELETE FROM entry_attachments WHERE org_id = 'org_alpha';
+    DELETE FROM blobs WHERE org_id = 'org_alpha';
+    DELETE FROM entries WHERE org_id = 'org_alpha' AND logical_path = 'Test/alpha-attach';
+
+    RESET ROLE;
+END;
+$$;
+
+DO $$
+BEGIN
+    SET LOCAL ROLE kb_admin;
+    SET LOCAL app.user_id = 'usr_demo_uploader';
+    SET LOCAL app.org_id = 'org_demo';
+    SET LOCAL app.role = 'admin';
+    SET LOCAL app.department = 'leadership';
+
+    DELETE FROM blobs
+    WHERE org_id = 'org_demo'
+      AND sha256 = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    RESET ROLE;
+END;
+$$;
+
 DO $$ BEGIN RAISE NOTICE '--- All validation tests complete ---'; END; $$;


### PR DESCRIPTION
## Summary

Ships the full file-attachments surface (closes #17): blob storage, multipart upload with dedup, PDF text extraction into the staging flow, signed-URL retrieval, MCP `upload_attachment` tool, tests, and docs.

- Migrations 022 (blobs + entry_attachments, forced RLS, cross-org isolation) and 023 (staging.submission_category += 'attachment_digest').
- Storage abstraction: `LocalStorage` (HMAC-SHA256 signed URLs) + `S3Storage` (lazy boto3; AWS/R2/MinIO via `S3_ENDPOINT_URL`), selected by `STORAGE_BACKEND`.
- `POST /attachments` streams SHA-256 dedup with a 413 gate; `GET /attachments/{blob_id}` returns 302 → signed URL with 404-not-403 semantics; `GET /attachments/_local/{key:path}` streams locally with HMAC verification; `GET /entries/{entry_id}/attachments` lists linked blobs under RLS.
- PDF digest: `?digest=true&content_type=application/pdf` creates a staging row; on promotion the `_promote_staging_item` create branch inserts `entry_attachments(role='source')` linking the new entry to the blob.
- MCP `upload_attachment(path, digest=True, content_type=None)` + `CortexClient.post_multipart` helper.
- `tests/test_attachments.py` (9 cases), `test_pdf_digest.py`, `test_storage.py`. Full suite: 59 passed / 5 skipped.
- `docs/ATTACHMENTS.md` + README Features row + `skill/references/api-reference.md` §16.

## Heads-up — migration-number collision

`db/migrations/023_staging_attachment_digest.sql` in this branch will collide with `023_access_log.sql` from the in-flight observability lane (#15) when both reach `dev`. Proposed ordering at merge:

1. This PR merges first → keeps `023_staging_attachment_digest.sql`.
2. Observability lane renumbers to `024_access_log.sql`.
3. Quick-strike lane renumbers `024_staging_nullable_content.sql` → `025_*`.

Sprint parent owns the reconciliation — flagging here so reviewers don't land it in the wrong order.

## Test plan

- [ ] `docker compose down -v && docker compose up -d` on a fresh volume — migrations 022 + 023 apply cleanly.
- [ ] `python3 -m pytest tests/ -q --ignore=mcp` → 59 passed / 5 skipped.
- [ ] `curl -F file=@fixture.pdf "localhost:8010/attachments?digest=true&content_type=application/pdf" -H "Authorization: Bearer $KEY"` returns `{blob_id, sha256, staging_id, ...}`.
- [ ] `GET /attachments/{blob_id}` → 302 → signed URL → bytes match upload SHA.
- [ ] Confirm migration ordering with reviewer before merge (see "Heads-up" above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)