### PR TITLE
fix: quick-strike bundle — #16 markdown links + #12 meta-only submit_staging

### DIFF
--- a/api/routes/staging.py
+++ b/api/routes/staging.py
@@ -218,6 +218,14 @@ async def _promote_staging_item(conn, staging: dict, approver_id: str) -> dict:
         effective_content = staging["proposed_content"] or current["content"]
         content_hash = hashlib.sha256(effective_content.encode()).hexdigest()
 
+        # Only override structural fields that were EXPLICITLY provided in
+        # proposed_meta. Using the defaulted locals (content_type defaults
+        # to "context", sensitivity to "shared") would silently rewrite
+        # fields on every meta-only update (e.g. a tag-only edit would
+        # reset content_type to "context"). See issue #12.
+        explicit_content_type = meta.get("content_type") if meta else None
+        explicit_sensitivity = meta.get("sensitivity") if meta else None
+
         await conn.execute(
             """
             UPDATE entries
@@ -238,9 +246,9 @@ async def _promote_staging_item(conn, staging: dict, approver_id: str) -> dict:
                 staging["proposed_title"],
                 effective_content,
                 content_hash,
-                content_type if meta else None,
+                explicit_content_type,
                 staging["target_path"],
-                sensitivity if meta else None,
+                explicit_sensitivity,
                 tags if tags else None,
                 json.dumps(domain_meta) if domain_meta else None,
                 new_version,
@@ -419,6 +427,23 @@ async def submit_staging(
             detail=f"proposed_content is required for {body.change_type} changes",
         )
 
+    # For updates: at least one of proposed_content / proposed_title /
+    # proposed_meta / content_type must be supplied — otherwise there is
+    # nothing to apply (issue #12).
+    if body.change_type == "update":
+        has_content = body.proposed_content is not None
+        has_title = body.proposed_title is not None
+        has_meta = bool(body.proposed_meta)
+        has_ct = body.content_type is not None
+        if not (has_content or has_title or has_meta or has_ct):
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "update requires at least one of proposed_content, "
+                    "proposed_title, proposed_meta, or content_type"
+                ),
+            )
+
     # content_type is required for create changes
     if body.change_type == "create" and not body.content_type:
         # Check proposed_meta fallback
@@ -447,9 +472,15 @@ async def submit_staging(
         role=user.role,
     )
 
-    content_hash = hashlib.sha256(
-        (body.proposed_content or "").encode()
-    ).hexdigest()
+    # For metadata-only updates (no proposed_content), leave content_hash
+    # NULL rather than hashing an empty string — otherwise every such
+    # submission shares sha256("") and would falsely collide in the
+    # Tier 2 duplicate-content check below.
+    content_hash = (
+        hashlib.sha256(body.proposed_content.encode()).hexdigest()
+        if body.proposed_content is not None
+        else None
+    )
 
     async with get_db(user) as conn:
         # Validate content_type against registry at submission time (not just promotion)
@@ -519,14 +550,18 @@ async def submit_staging(
 
             # Tier 2 additional conflict checks
             if governance_tier == 2:
-                # Check for duplicate content hash in entries
-                cur3 = await conn.execute(
-                    "SELECT id FROM entries WHERE content_hash = %s AND org_id = %s LIMIT 1",
-                    (content_hash, user.org_id),
-                )
-                dup = await cur3.fetchone()
-                if dup:
-                    escalation_reasons.append(f"Duplicate content_hash — matches entry {dup[0]}")
+                # Check for duplicate content hash in entries — only when
+                # we actually have a hash. Metadata-only updates (no
+                # proposed_content) skip this check; otherwise every such
+                # submission would collide on sha256("").
+                if content_hash is not None:
+                    cur3 = await conn.execute(
+                        "SELECT id FROM entries WHERE content_hash = %s AND org_id = %s LIMIT 1",
+                        (content_hash, user.org_id),
+                    )
+                    dup = await cur3.fetchone()
+                    if dup:
+                        escalation_reasons.append(f"Duplicate content_hash — matches entry {dup[0]}")
 
                 # Check for other pending items targeting the same entry
                 if body.target_entry_id:
@@ -721,14 +756,17 @@ async def process_staging(
                 issues.append(f"Invalid content_type '{proposed_type}'")
 
             # --- Check 2: Duplicate detection (content_hash) ---
-            cur = await conn.execute(
-                "SELECT id FROM entries WHERE content_hash = %s AND org_id = %s LIMIT 1",
-                (item["content_hash"], item["org_id"]),
-            )
-            dup = await cur.fetchone()
-            if dup:
-                issues.append(f"Duplicate content_hash — matches entry {dup[0]}")
-                action = "deferred"
+            # Skip for metadata-only items where content_hash is NULL
+            # (no body content to dedupe on).
+            if item["content_hash"] is not None:
+                cur = await conn.execute(
+                    "SELECT id FROM entries WHERE content_hash = %s AND org_id = %s LIMIT 1",
+                    (item["content_hash"], item["org_id"]),
+                )
+                dup = await cur.fetchone()
+                if dup:
+                    issues.append(f"Duplicate content_hash — matches entry {dup[0]}")
+                    action = "deferred"
 
             # --- Check 3: Conflict detection (same target_entry_id, multiple pending) ---
             if item["target_entry_id"] and str(item["target_entry_id"]) in conflicting_targets:

--- a/api/services/links.py
+++ b/api/services/links.py
@@ -1,14 +1,23 @@
-"""Shared helper for populating `entry_links` from wiki-link references in entry content.
+"""Shared helper for populating `entry_links` from cross-entry references in entry content.
 
 Called from every write path (`create_entry`, `update_entry`, bulk
 `import_files`) so that the read-time resolver (`services/render.py::resolve_wiki_links`,
 spec 0028) has data to resolve. Before this existed, only the bulk importer
 populated `entry_links` and MCP/UI-authored entries rendered `[[...]]` literally.
 
+Two reference forms are extracted:
+
+- ``[[wiki-link]]`` — Obsidian-style wiki links (preferred for cross-entry refs).
+- ``[label](target)`` — standard markdown links, when ``target`` looks like an
+  internal reference (no scheme, not an anchor, not an absolute path, not an
+  image). External links (URLs / mailto / images / anchors) are skipped.
+
 Match strategy mirrors migration 021 + the original inlined logic in
 `import_files.py`: resolve by `LOWER(logical_path)` tail segment first (the
 form wiki-links use — `[[person-gareth-prenderson]]`), then fall back to
-full `LOWER(logical_path)` and `LOWER(title)`.
+full `LOWER(logical_path)` and `LOWER(title)`. Both reference forms use the
+same resolver and dedup against each other so a single target referenced as
+both ``[[foo]]`` and ``[Foo](foo)`` produces exactly one ``entry_links`` row.
 """
 
 from __future__ import annotations
@@ -16,6 +25,30 @@ from __future__ import annotations
 import re
 
 _WIKI_LINK_RE = re.compile(r"\[\[([^\]|#]+)")
+# Capture the character preceding the `[` so we can reject image syntax
+# (`![alt](src)`). Group 1 is the leading char (or empty at string start),
+# group 2 is the link label, group 3 is the target.
+_MARKDOWN_LINK_RE = re.compile(r"(^|[^!])\[([^\]]+)\]\(([^)]+)\)")
+
+
+def _is_internal_md_target(target: str) -> bool:
+    """Return True if a markdown link target looks like an internal entry ref.
+
+    Skip URLs (anything containing `://` — http, https, mailto:, ftp, etc.),
+    in-page anchors (starting with `#`), and absolute filesystem/URL paths
+    (starting with `/`). Image syntax is filtered upstream by the regex
+    refusing to match when the preceding char is `!`.
+    """
+    if not target:
+        return False
+    t = target.strip()
+    if not t:
+        return False
+    if "://" in t:
+        return False
+    if t.startswith("#") or t.startswith("/"):
+        return False
+    return True
 
 
 async def sync_entry_links(
@@ -44,17 +77,24 @@ async def sync_entry_links(
         (entry_id_s,),
     )
 
-    if not content or "[[" not in content:
+    # Cheap sniff: bail only when neither reference form can possibly match.
+    if not content or ("[[" not in content and "](" not in content):
         return 0
 
-    targets = _WIKI_LINK_RE.findall(content)
-    if not targets:
+    wiki_targets = _WIKI_LINK_RE.findall(content)
+    md_targets = [
+        target
+        for _prev, _label, target in _MARKDOWN_LINK_RE.findall(content)
+        if _is_internal_md_target(target)
+    ]
+    if not wiki_targets and not md_targets:
         return 0
 
-    # Dedup while preserving order.
+    # Dedup across both forms while preserving order. Wiki links scan first
+    # (historical order) so a target referenced both ways resolves once.
     seen: set[str] = set()
     unique_targets: list[str] = []
-    for t in targets:
+    for t in (*wiki_targets, *md_targets):
         key = t.strip()
         if key and key.lower() not in seen:
             seen.add(key.lower())

--- a/db/migrations/024_staging_proposed_content_nullable.sql
+++ b/db/migrations/024_staging_proposed_content_nullable.sql
@@ -1,0 +1,28 @@
+-- 024_staging_proposed_content_nullable.sql
+-- Allow `staging.proposed_content` to be NULL for metadata-only updates.
+--
+-- Issue: #12 — submit_staging 500s on proposed_meta-only updates.
+-- Root cause: db/migrations/003_governance.sql:26 declares
+--   `proposed_content TEXT NOT NULL`, but the Pydantic model
+--   (api/models.py:219) and submit_staging handler intentionally
+--   accept `None` for metadata-only updates (e.g. tag-only edits).
+--   The unhandled NotNullViolation surfaces as HTTP 500.
+--
+-- Fix: drop the NOT NULL on proposed_content. The promote path
+-- (api/routes/staging.py::_promote_staging_item, line 218)
+-- already coalesces `staging["proposed_content"] or current["content"]`,
+-- so promotion is unaffected.
+--
+-- Idempotent: `ALTER COLUMN ... DROP NOT NULL` is a no-op when the
+-- constraint is already absent in PostgreSQL.
+--
+-- We also drop NOT NULL on `content_hash` for the same reason — when
+-- `proposed_content` is NULL there is nothing to hash, and storing
+-- sha256("") for every meta-only submission would falsely collide in
+-- the Tier 2 duplicate-content check.
+
+ALTER TABLE staging
+    ALTER COLUMN proposed_content DROP NOT NULL;
+
+ALTER TABLE staging
+    ALTER COLUMN content_hash DROP NOT NULL;

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -368,6 +368,17 @@ If the content type is ambiguous, check the type registry (loaded at session sta
 5. **Link to related entries** if relationships exist
 6. **Report** — entry title, path, and ID
 
+### Cross-Entry References in Content
+
+When entry content references another entry, two link forms are extracted on write and resolved on read into clickable references:
+
+- ``[[slug-or-title]]`` — Obsidian-style wiki link. **Preferred** — most compact, unambiguous, and matches the seeded vault convention.
+- ``[label](slug-or-title)`` — standard markdown link. Also extracted; use this when you want a custom display label or when the content is being authored in a markdown editor that doesn't speak wiki-link syntax.
+
+Both forms resolve via the same strategy (logical-path tail segment → full logical path → title) and dedup against each other, so writing `[[foo]]` and `[Foo](foo)` in the same entry produces exactly one outgoing link. URLs (`https://...`, `mailto:...`), in-page anchors (`#section`), absolute paths (`/path`), and image syntax (`![alt](src)`) are never extracted as entry references — link freely without worrying about false positives.
+
+Use `create_link` only when you need a typed link (`mentions`, `supersedes`, etc.) or when no plausible reference text fits inside the body — the in-body forms cover the common case.
+
 ### Bulk Ingestion
 
 For per-entry creates from a conversation or a single inbox file, use `create_entry` / `submit_staging` as above. For bulk imports from a coherent source (an Obsidian vault, an existing wiki export, a folder with ≥10 markdown files), reach for `import_vault`:

--- a/tests/test_entries_write.py
+++ b/tests/test_entries_write.py
@@ -195,3 +195,108 @@ def test_unknown_slug_produces_no_rows_without_error(target_entry):
         assert "[[does-not-exist-xyz]]" in rendered
     finally:
         _archive(source["id"])
+
+
+# ---------------------------------------------------------------------------
+# Markdown-link extraction (issue #16, T-0195).
+#
+# `sync_entry_links` historically only matched `[[wiki-link]]` references.
+# These tests cover the four cases from the issue: markdown links to existing
+# entries resolve, markdown links to unknown targets are silently skipped,
+# mixed wiki + markdown links both resolve, and same-target dedup across forms
+# produces exactly one entry_links row. URLs / anchors / images must NOT be
+# extracted.
+# ---------------------------------------------------------------------------
+
+
+def test_create_with_markdown_link_writes_entry_links_row(target_entry):
+    """[label](slug) to an existing entry produces one entry_links row."""
+    target, suffix = target_entry
+    slug = f"target-{suffix}"
+    source = _create(
+        title=f"Source MD-A {suffix}",
+        content=f"See [the target]({slug}) for details.",
+        logical_path=f"writelinks/source-md-a-{suffix}",
+    )
+    try:
+        assert _link_count(source["id"]) == 1
+        rendered = _get(source["id"])["content"]
+        # The markdown form is preserved as-is in stored content; what matters
+        # is that the entry_links row exists for downstream graph queries.
+        assert f"({slug})" in rendered or f"(/kb/{target['id']})" in rendered
+    finally:
+        _archive(source["id"])
+
+
+def test_markdown_link_to_unknown_target_is_silently_skipped(target_entry):
+    """Markdown link to a non-existent slug writes no row and does not error."""
+    _target, suffix = target_entry
+    source = _create(
+        title=f"Source MD-B {suffix}",
+        content="See [missing thing](does-not-exist-xyz-md) for details.",
+        logical_path=f"writelinks/source-md-b-{suffix}",
+    )
+    try:
+        assert _link_count(source["id"]) == 0
+        # Body should round-trip without 500 / mangling.
+        rendered = _get(source["id"])["content"]
+        assert "does-not-exist-xyz-md" in rendered
+    finally:
+        _archive(source["id"])
+
+
+def test_mixed_wiki_and_markdown_links_both_resolve():
+    """A source referencing two distinct targets via wiki + markdown forms
+    produces exactly two entry_links rows."""
+    suffix = uuid.uuid4().hex[:10]
+    target_a = _create(
+        title=f"writelinks/mix-target-a-{suffix}",
+        content="Target A.",
+        logical_path=f"writelinks/mix-target-a-{suffix}",
+    )
+    target_b = _create(
+        title=f"writelinks/mix-target-b-{suffix}",
+        content="Target B.",
+        logical_path=f"writelinks/mix-target-b-{suffix}",
+    )
+    slug_a = f"mix-target-a-{suffix}"
+    slug_b = f"mix-target-b-{suffix}"
+    source = _create(
+        title=f"Source MIX {suffix}",
+        content=(
+            f"Wiki reference to [[{slug_a}]] and markdown reference to "
+            f"[the other]({slug_b}).\n\n"
+            # Image syntax — must be ignored.
+            f"![an image](https://example.com/foo.png)\n\n"
+            # External URL — must be ignored.
+            f"See [docs](https://example.com/docs) for details.\n\n"
+            # Anchor — must be ignored.
+            f"Jump to [section](#somewhere)."
+        ),
+        logical_path=f"writelinks/source-mix-{suffix}",
+    )
+    try:
+        assert _link_count(source["id"]) == 2
+    finally:
+        _archive(source["id"])
+        _archive(target_a["id"])
+        _archive(target_b["id"])
+
+
+def test_same_target_via_wiki_and_markdown_dedupes_to_one_row(target_entry):
+    """Linking to the same target as both [[slug]] and [label](slug) writes
+    exactly one entry_links row (cross-form dedup)."""
+    target, suffix = target_entry
+    slug = f"target-{suffix}"
+    source = _create(
+        title=f"Source DEDUP {suffix}",
+        content=(
+            f"First reference: [[{slug}]].\n\n"
+            f"Second reference (markdown): [same target]({slug})."
+        ),
+        logical_path=f"writelinks/source-dedup-{suffix}",
+    )
+    try:
+        assert _link_count(source["id"]) == 1
+    finally:
+        _archive(source["id"])

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -1,0 +1,246 @@
+"""Tests for the staging / governance pipeline (issue #12, T-0196).
+
+Covers metadata-only staging submissions: a `change_type: update` with
+`proposed_meta` but no `proposed_content` must succeed (201) and apply the
+new meta fields without disturbing `content`. Previously the NOT NULL
+constraint on `staging.proposed_content` surfaced as a bare 500.
+
+Prerequisites:
+  1. docker compose up -d   (API on :8010, Postgres on :5442)
+     Migrations through 024 must be applied (fresh volume if upgrading).
+  2. pip install -r tests/requirements-dev.txt
+
+Run:
+  pytest tests/test_staging.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+import requests
+
+
+BASE_URL = os.environ.get("CORTEX_BASE_URL", "http://localhost:8010")
+ADMIN_KEY = "bkai_adm1_testkey_admin"
+REQUEST_TIMEOUT = 10.0
+
+
+def _headers(key: str = ADMIN_KEY) -> dict:
+    return {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
+
+
+def _api_available() -> bool:
+    try:
+        return requests.get(f"{BASE_URL}/health", timeout=2.0).status_code == 200
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _api_available(),
+    reason=f"Brilliant API not reachable at {BASE_URL} (start `docker compose up -d`).",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_entry(title: str, content: str, logical_path: str, tags=None) -> dict:
+    body = {
+        "title": title,
+        "content": content,
+        "content_type": "context",
+        "logical_path": logical_path,
+        "sensitivity": "shared",
+        "tags": tags or ["test", "staging-fixture"],
+    }
+    r = requests.post(
+        f"{BASE_URL}/entries",
+        headers=_headers(),
+        json=body,
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r.status_code == 201, f"create failed: {r.status_code} {r.text}"
+    return r.json()
+
+
+def _get_entry(entry_id: str) -> dict:
+    r = requests.get(
+        f"{BASE_URL}/entries/{entry_id}",
+        headers=_headers(),
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _archive(entry_id: str) -> None:
+    try:
+        requests.delete(
+            f"{BASE_URL}/entries/{entry_id}",
+            headers=_headers(),
+            timeout=REQUEST_TIMEOUT,
+        )
+    except Exception:
+        pass
+
+
+def _submit_staging(payload: dict) -> requests.Response:
+    return requests.post(
+        f"{BASE_URL}/staging",
+        headers=_headers(),
+        json=payload,
+        timeout=REQUEST_TIMEOUT,
+    )
+
+
+@pytest.fixture
+def fresh_entry():
+    suffix = uuid.uuid4().hex[:10]
+    entry = _create_entry(
+        title=f"staging-target-{suffix}",
+        content="Original body — must remain unchanged after meta-only update.",
+        logical_path=f"staging-tests/target-{suffix}",
+        tags=["original-tag"],
+    )
+    yield entry
+    _archive(entry["id"])
+
+
+# ---------------------------------------------------------------------------
+# Tests — issue #12
+# ---------------------------------------------------------------------------
+
+
+def test_meta_only_update_returns_201_and_preserves_content(fresh_entry):
+    """An update with only proposed_meta (no proposed_content) must succeed
+    and leave the entry's content untouched after auto-promotion."""
+    original_content = fresh_entry["content"]
+    new_tags = ["seed", "test-data", uuid.uuid4().hex[:6]]
+
+    r = _submit_staging({
+        "target_entry_id": fresh_entry["id"],
+        "target_path": fresh_entry["logical_path"],
+        "change_type": "update",
+        "proposed_meta": {"tags": new_tags},
+    })
+    assert r.status_code == 201, f"expected 201, got {r.status_code}: {r.text}"
+    body = r.json()
+    # Admin web_ui keys auto-promote at Tier 1.
+    assert body["status"] == "auto_approved", body
+    assert body["promoted_entry_id"] == fresh_entry["id"], body
+
+    # Entry now has the new tags but the original content.
+    refreshed = _get_entry(fresh_entry["id"])
+    assert refreshed["content"] == original_content, (
+        f"content mutated by meta-only update: {refreshed['content']!r}"
+    )
+    assert set(new_tags).issubset(set(refreshed["tags"])), refreshed["tags"]
+
+
+def test_update_with_neither_content_nor_meta_returns_422(fresh_entry):
+    """A no-op update (no content, no title, no meta, no content_type)
+    has nothing to apply and must be rejected as 422 — never 500."""
+    r = _submit_staging({
+        "target_entry_id": fresh_entry["id"],
+        "target_path": fresh_entry["logical_path"],
+        "change_type": "update",
+    })
+    assert r.status_code == 422, f"expected 422, got {r.status_code}: {r.text}"
+    detail = r.json().get("detail", "")
+    assert "update requires at least one" in detail, detail
+
+
+def test_bulk_meta_only_update_across_ten_entries():
+    """Bulk-tagging 10 distinct entries with meta-only updates must all
+    succeed without any 500s. Regression test for the original NotNull
+    crash that landed when callers tried to script this workflow."""
+    suffix = uuid.uuid4().hex[:8]
+    created: list[dict] = []
+    try:
+        for i in range(10):
+            created.append(_create_entry(
+                title=f"bulk-tag-{suffix}-{i}",
+                content=f"Body {i} for bulk-tag regression test.",
+                logical_path=f"staging-tests/bulk-{suffix}/entry-{i}",
+            ))
+
+        common_tag = f"bulk-{suffix}"
+        for entry in created:
+            r = _submit_staging({
+                "target_entry_id": entry["id"],
+                "target_path": entry["logical_path"],
+                "change_type": "update",
+                "proposed_meta": {"tags": [common_tag, "bulk-fixture"]},
+            })
+            assert r.status_code == 201, (
+                f"bulk meta-only update failed for {entry['id']}: "
+                f"{r.status_code} {r.text}"
+            )
+            assert r.json()["status"] == "auto_approved"
+
+        # All 10 entries now carry the common tag, content unchanged.
+        for entry in created:
+            refreshed = _get_entry(entry["id"])
+            assert common_tag in refreshed["tags"], refreshed["tags"]
+            assert refreshed["content"].startswith("Body "), refreshed["content"]
+    finally:
+        for entry in created:
+            _archive(entry["id"])
+
+
+def test_update_with_content_still_works(fresh_entry):
+    """Regression: existing update-with-content path must still succeed
+    and overwrite content as before."""
+    new_body = f"Replacement body {uuid.uuid4().hex[:6]}"
+    r = _submit_staging({
+        "target_entry_id": fresh_entry["id"],
+        "target_path": fresh_entry["logical_path"],
+        "change_type": "update",
+        "proposed_content": new_body,
+    })
+    assert r.status_code == 201, f"{r.status_code} {r.text}"
+    assert r.json()["status"] == "auto_approved"
+
+    refreshed = _get_entry(fresh_entry["id"])
+    assert refreshed["content"] == new_body, refreshed["content"]
+
+
+def test_meta_only_update_does_not_collide_on_empty_hash(fresh_entry):
+    """Regression: prior to the fix every meta-only update hashed the
+    empty string, causing the second one to (a) match other meta-only
+    submissions on content_hash and (b) potentially escalate via the
+    Tier 2 dup check. With the fix, content_hash for meta-only is NULL
+    and successive meta-only updates auto-approve cleanly."""
+    suffix = uuid.uuid4().hex[:6]
+    other = _create_entry(
+        title=f"sibling-{suffix}",
+        content="Sibling body — different from fresh_entry.",
+        logical_path=f"staging-tests/sibling-{suffix}",
+    )
+    try:
+        r1 = _submit_staging({
+            "target_entry_id": fresh_entry["id"],
+            "target_path": fresh_entry["logical_path"],
+            "change_type": "update",
+            "proposed_meta": {"tags": [f"first-{suffix}"]},
+        })
+        assert r1.status_code == 201, r1.text
+        assert r1.json()["status"] == "auto_approved", r1.json()
+
+        r2 = _submit_staging({
+            "target_entry_id": other["id"],
+            "target_path": other["logical_path"],
+            "change_type": "update",
+            "proposed_meta": {"tags": [f"second-{suffix}"]},
+        })
+        assert r2.status_code == 201, r2.text
+        # Must NOT be escalated to pending due to a fake hash collision.
+        assert r2.json()["status"] == "auto_approved", r2.json()
+    finally:
+        _archive(other["id"])


### PR DESCRIPTION
## Summary
Sprint 0034 Lane 4 (quick-strike) — two independent fixes bundled on the same branch.

- **#16 (T-0195)** — `sync_entry_links` now extracts `[label](target)` markdown links in addition to `[[wiki-links]]`. URL / anchor / image / absolute-path targets are filtered. Both forms share the same resolver and dedup against each other.
- **#12 (T-0196)** — `submit_staging` no longer 500s on meta-only updates. Migration 024 drops `NOT NULL` on `staging.proposed_content` + `content_hash`; meta-only submissions store `content_hash=NULL` (avoids false Tier 2 dup-check collisions on `sha256('')`); 422 guard on truly no-op submissions. Bonus: fixed a latent bug in `_promote_staging_item` where tag-only updates silently reset `content_type` to `"context"`.

## Test plan
- [x] `pytest tests/` — 44/44 green (incl. new `tests/test_staging.py` + markdown-link cases in `tests/test_entries_write.py`)
- [x] Manual: both issues reproduce on `dev`, both resolved on this branch
- [ ] Reviewer: sanity-check migration 024 on a fresh `docker compose down -v && up -d`

Closes #16
Closes #12