### PR TITLE
refactor: Cortex → Brilliant rename (Sprint 0035)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,20 +7,20 @@
 # --- Database (dev defaults safe for local) ---
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=dev
-POSTGRES_DB=cortex
+POSTGRES_DB=brilliant
 # DATABASE_URL is built from the above in docker-compose.yml.
 # Only override if connecting to an external database.
-# DATABASE_URL=postgresql://postgres:dev@db:5432/cortex
+# DATABASE_URL=postgresql://postgres:dev@db:5432/brilliant
 
 # --- API server ---
-# CORTEX_BASE_URL is set automatically inside docker-compose.
+# BRILLIANT_BASE_URL is set automatically inside docker-compose.
 # Override only for external/non-Docker API access.
-# CORTEX_BASE_URL=http://localhost:8010
+# BRILLIANT_BASE_URL=http://localhost:8010
 
-# CORTEX_API_KEY is issued at admin bootstrap (see ADMIN_* below).
+# BRILLIANT_API_KEY is issued at admin bootstrap (see ADMIN_* below).
 # After first run, copy the key from the API logs and set it here
 # so the MCP server can authenticate.
-# CORTEX_API_KEY=
+# BRILLIANT_API_KEY=
 
 # --- MCP server (Claude Co-work / Claude Code integration) ---
 # Public-facing URL where the MCP server is reachable.

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -17,10 +17,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - image: cortex-api
+          - image: brilliant-api
             context: ./api
             dockerfile: ./api/Dockerfile
-          - image: cortex-mcp
+          - image: brilliant-mcp
             context: ./mcp
             dockerfile: ./mcp/Dockerfile
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ tests/concurrency_harness.py
 # Test/cache
 .pytest_cache/
 
+# Installer artifacts
+install.log
+brilliant-credentials.txt
+
 # ─── Private maintainer surfaces — never commit ───────────────
 # These paths are used locally for planning, marketing, research,
 # and video production. They must not land in the public repo.

--- a/api/admin_bootstrap.py
+++ b/api/admin_bootstrap.py
@@ -15,7 +15,7 @@ import secrets
 
 import bcrypt
 
-logger = logging.getLogger("cortex.admin_bootstrap")
+logger = logging.getLogger("brilliant.admin_bootstrap")
 
 
 def _generate_api_key() -> str:

--- a/api/database.py
+++ b/api/database.py
@@ -11,7 +11,7 @@ from psycopg_pool import AsyncConnectionPool
 
 DATABASE_URL = os.getenv(
     "DATABASE_URL",
-    "postgresql://postgres:dev@localhost:5432/cortex",
+    "postgresql://postgres:dev@localhost:5432/brilliant",
 )
 
 _pool: AsyncConnectionPool | None = None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,25 @@
 services:
   db:
     image: pgvector/pgvector:pg16
-    container_name: cortex-db
+    container_name: brilliant-db
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-dev}
-      POSTGRES_DB: ${POSTGRES_DB:-cortex}
+      POSTGRES_DB: ${POSTGRES_DB:-brilliant}
     ports:
       - "5442:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./db/migrations:/docker-entrypoint-initdb.d
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d cortex"]
+      test: ["CMD-SHELL", "pg_isready -U postgres -d brilliant"]
       interval: 5s
       timeout: 5s
       retries: 5
 
   api:
     build: ./api
-    container_name: cortex-api
+    container_name: brilliant-api
     depends_on:
       db:
         condition: service_healthy
@@ -28,7 +28,7 @@ services:
     volumes:
       - ./api:/app
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-dev}@db:5432/${POSTGRES_DB:-cortex}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-dev}@db:5432/${POSTGRES_DB:-brilliant}
       ADMIN_EMAIL: ${ADMIN_EMAIL:-}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-}
       ADMIN_API_KEY: ${ADMIN_API_KEY:-}
@@ -37,7 +37,7 @@ services:
 
   mcp:
     build: ./mcp
-    container_name: cortex-mcp
+    container_name: brilliant-mcp
     depends_on:
       db:
         condition: service_healthy
@@ -48,11 +48,11 @@ services:
     volumes:
       - ./mcp:/app
     environment:
-      CORTEX_BASE_URL: http://api:8000
-      CORTEX_API_KEY: ${CORTEX_API_KEY:-}
+      BRILLIANT_BASE_URL: http://api:8000
+      BRILLIANT_API_KEY: ${BRILLIANT_API_KEY:-}
       MCP_BASE_URL: ${MCP_BASE_URL:-http://localhost:8011}
       MCP_PORT: "8001"
-      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-dev}@db:5432/${POSTGRES_DB:-cortex}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-dev}@db:5432/${POSTGRES_DB:-brilliant}
     restart: unless-stopped
 
 volumes:

--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,7 @@ KEY_OUT="${DEFAULT_KEY_OUT}"
 FORCE=0
 NO_INSTALL_DOCKER=0
 DRY_RUN=0
+MIGRATE_FROM_CORTEX=0
 
 # ---------- logging ----------
 
@@ -99,6 +100,10 @@ Optional:
   --force                    Overwrite existing .env.
   --no-install-docker        Detect Docker only; fail if missing.
   --dry-run                  Print the 8-phase plan and exit 0.
+  --migrate-from-cortex      Upgrade a pre-rename cortex-* stack in place:
+                             rename the cortex DB to brilliant, tear down old
+                             containers, and bring up the renamed stack with
+                             the existing data volume preserved.
   -h, --help                 Show this message.
 
 Examples:
@@ -129,6 +134,7 @@ parse_flags() {
       --force)               FORCE=1; shift ;;
       --no-install-docker)   NO_INSTALL_DOCKER=1; shift ;;
       --dry-run)             DRY_RUN=1; shift ;;
+      --migrate-from-cortex) MIGRATE_FROM_CORTEX=1; shift ;;
       -h|--help)             print_help; exit 0 ;;
       *) die 64 "Unknown flag: $1 (try --help)" ;;
     esac
@@ -142,8 +148,8 @@ require_bash4() {
     die 65 "Not running under bash."
   fi
   local major="${BASH_VERSION%%.*}"
-  if [ "$major" -lt 4 ]; then
-    die 65 "bash 4+ required (got $BASH_VERSION). On macOS: 'brew install bash' and rerun."
+  if [ "$major" -lt 3 ]; then
+    die 65 "bash 3.2+ required (got $BASH_VERSION)."
   fi
 }
 
@@ -373,6 +379,143 @@ phase_summary() {
 BANNER
 }
 
+# ---------- migration: cortex → brilliant ----------
+
+container_running() {
+  # $1 container name. Returns 0 if running, non-zero otherwise.
+  local name="$1"
+  local state
+  state="$(docker inspect -f '{{.State.Running}}' "$name" 2>/dev/null || true)"
+  [ "$state" = "true" ]
+}
+
+run_cmd() {
+  # Print the command; execute only when DRY_RUN=0.
+  # Usage: run_cmd docker stop cortex-api
+  log "migrate" "\$ $*"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    "$@"
+  fi
+}
+
+phase_migrate_from_cortex() {
+  log "migrate" "upgrade path: cortex-* → brilliant-*"
+
+  # Step 1: detect. Three cases to disambiguate:
+  #   - cortex-db running                  → migrate
+  #   - brilliant-db running, no cortex-db → already migrated, exit 0
+  #   - neither running                    → nothing to migrate, exit 1
+  local has_cortex_db=0
+  local has_brilliant_db=0
+  if container_running cortex-db; then has_cortex_db=1; fi
+  if container_running brilliant-db; then has_brilliant_db=1; fi
+
+  if [ "$has_cortex_db" -eq 0 ] && [ "$has_brilliant_db" -eq 1 ]; then
+    log "migrate" "brilliant-db is already running and cortex-db is not — already migrated."
+    exit 0
+  fi
+  if [ "$has_cortex_db" -eq 0 ] && [ "$has_brilliant_db" -eq 0 ]; then
+    die 76 "neither cortex-db nor brilliant-db is running — nothing to migrate. Run ./install.sh for a fresh install."
+  fi
+  if [ "$has_cortex_db" -eq 0 ]; then
+    log "migrate" "no cortex-* stack detected; nothing to migrate"
+    exit 0
+  fi
+
+  log "migrate" "detected running cortex-db — proceeding with migration"
+
+  # Step 2: quiesce writers. Stop cortex-api and cortex-mcp if present so the
+  # ALTER DATABASE below doesn't trip on live connections. Ignore failures for
+  # containers that don't exist; surface them only if the rename later fails.
+  log "migrate" "step 2: stop cortex-api and cortex-mcp (quiesce writers)"
+  if container_running cortex-api; then
+    run_cmd docker stop cortex-api
+  else
+    log "migrate" "cortex-api not running — skipping stop"
+  fi
+  if container_running cortex-mcp; then
+    run_cmd docker stop cortex-mcp
+  else
+    log "migrate" "cortex-mcp not running — skipping stop"
+  fi
+
+  # Step 3: rename the database. Any live connection to the `cortex` DB will
+  # cause this to fail — we surface a clear error in that case.
+  log "migrate" "step 3: ALTER DATABASE cortex RENAME TO brilliant"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    if ! docker exec cortex-db psql -U postgres -c \
+        "ALTER DATABASE cortex RENAME TO brilliant" 2>&1 | tee -a "$LOG_FILE"; then
+      log "migrate" "rename failed — checking for lingering connections"
+      docker ps --filter "name=cortex-" --format '  still up: {{.Names}}' \
+        2>&1 | tee -a "$LOG_FILE" || true
+      die 77 "ALTER DATABASE cortex RENAME TO brilliant failed. See ${LOG_FILE}. Migration aborted before teardown; cortex-db is still intact."
+    fi
+  else
+    log "migrate" "\$ docker exec cortex-db psql -U postgres -c 'ALTER DATABASE cortex RENAME TO brilliant'"
+  fi
+
+  # Step 4: tear down old cortex containers. Remove by explicit name so we
+  # don't depend on a prior compose file being present on disk. The Postgres
+  # data volume (pgdata) is unaffected — the renamed `brilliant` database
+  # lives inside it and is mounted by brilliant-db in step 5.
+  log "migrate" "step 4: remove old cortex containers (data volume preserved)"
+  run_cmd docker rm -f cortex-db cortex-api cortex-mcp
+
+  # Step 5: bring up the renamed stack. docker-compose.yml on this branch
+  # already names the containers brilliant-*.
+  log "migrate" "step 5: docker compose up -d --build (brilliant-*)"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    docker compose up -d --build 2>&1 | tee -a "$LOG_FILE"
+  else
+    log "migrate" "\$ docker compose up -d --build"
+  fi
+
+  # Step 6: verify health + the renamed DB is visible.
+  log "migrate" "step 6: verify brilliant-api /health and brilliant DB exists"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    local waited=0
+    while [ "$waited" -lt "$HEALTH_TIMEOUT_SECONDS" ]; do
+      if curl -fsS "${API_URL}/health" >/dev/null 2>&1; then
+        log "migrate" "brilliant-api healthy at ${API_URL}"
+        break
+      fi
+      sleep "$POLL_INTERVAL_SECONDS"
+      waited=$((waited + POLL_INTERVAL_SECONDS))
+    done
+    if [ "$waited" -ge "$HEALTH_TIMEOUT_SECONDS" ]; then
+      docker compose logs api --tail 50 2>&1 | tee -a "$LOG_FILE" || true
+      die 78 "brilliant-api did not become healthy within ${HEALTH_TIMEOUT_SECONDS}s after migration. See ${LOG_FILE}."
+    fi
+    if ! docker exec brilliant-db psql -U postgres -lqt | grep -q '\bbrilliant\b'; then
+      die 79 "brilliant database not found inside brilliant-db after migration. See ${LOG_FILE}."
+    fi
+    log "migrate" "brilliant database present in brilliant-db"
+  else
+    log "migrate" "\$ curl -fsS ${API_URL}/health  (poll up to ${HEALTH_TIMEOUT_SECONDS}s)"
+    log "migrate" "\$ docker exec brilliant-db psql -U postgres -lqt | grep brilliant"
+  fi
+
+  # Step 7: summary.
+  log "migrate" "step 7: summary"
+  cat <<MIGRATED
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Migrated cortex → brilliant. Data preserved.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  New containers: brilliant-db, brilliant-api, brilliant-mcp
+  Database:       brilliant (renamed from cortex, same data volume)
+  API:            ${API_URL}
+
+  Your existing .env values (POSTGRES_PASSWORD, ADMIN_*) are unchanged.
+  If you previously hard-coded POSTGRES_DB=cortex in .env, update it to
+  POSTGRES_DB=brilliant to match the renamed database.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+MIGRATED
+}
+
 # ---------- dry-run plan ----------
 
 print_plan() {
@@ -407,8 +550,29 @@ PLAN
 main() {
   parse_flags "$@"
 
-  if [ -z "$ADMIN_EMAIL" ]; then
+  # --migrate-from-cortex is a dedicated upgrade path and does not require
+  # --admin-email — the admin user already exists in the preserved DB.
+  if [ "$MIGRATE_FROM_CORTEX" -eq 0 ] && [ -z "$ADMIN_EMAIL" ]; then
     die 64 "--admin-email is required (try --help)"
+  fi
+
+  if [ "$MIGRATE_FROM_CORTEX" -eq 1 ]; then
+    # Log file: fresh for a real run, left alone for --dry-run.
+    if [ "$DRY_RUN" -eq 0 ]; then
+      : >"$LOG_FILE"
+    fi
+    log "phase 0" "install.sh v${SCRIPT_VERSION} --migrate-from-cortex starting"
+    phase_preflight
+    # Docker must already be present to have a cortex-* stack at all; detect
+    # only. We don't want to install or restart Docker as part of migration.
+    if ! docker_present; then
+      die 80 "docker not available — cannot detect or migrate an existing cortex-* stack"
+    fi
+    if ! docker_compose_v2_present; then
+      die 73 "docker compose V2 not available. Upgrade Docker (>=20.10) and rerun."
+    fi
+    phase_migrate_from_cortex
+    exit 0
   fi
 
   if [ "$DRY_RUN" -eq 1 ]; then

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -22,13 +22,11 @@ uv pip install -r requirements.txt
 
 | Env Var | Default | Description |
 |---|---|---|
-| `CORTEX_BASE_URL` | `http://localhost:8010` | Brilliant API base URL |
-| `CORTEX_API_KEY` | *(required)* | Bearer token for API auth |
+| `BRILLIANT_BASE_URL` | `http://localhost:8010` | Brilliant API base URL |
+| `BRILLIANT_API_KEY` | *(required)* | Bearer token for API auth |
 | `MCP_BASE_URL` | `http://localhost:8011` | External URL for OAuth issuer (remote only) |
 | `MCP_PORT` | `8001` | Port for remote HTTP server |
 | `TOKEN_EXPIRY_SECONDS` | `3600` | OAuth access token lifetime |
-
-> Note: `CORTEX_BASE_URL` / `CORTEX_API_KEY` env var names are preserved as infrastructure identifiers across the Cortex→Brilliant rename. Deployments already using them don't need to change configuration.
 
 ## Claude Desktop Integration (Stdio)
 
@@ -42,7 +40,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
       "args": ["/absolute/path/to/xireactor-brilliant/mcp/server.py"],
       "env": {
         "PYTHONUNBUFFERED": "1",
-        "CORTEX_API_KEY": "bkai_adm1_testkey_admin"
+        "BRILLIANT_API_KEY": "bkai_adm1_testkey_admin"
       }
     }
   }
@@ -77,7 +75,7 @@ Restart Claude Desktop after editing the config. The 11 Brilliant tools will app
 
 2. Set the API key as an environment variable on the MCP container:
    ```bash
-   CORTEX_API_KEY=bkai_XXXX_your_org_key
+   BRILLIANT_API_KEY=bkai_XXXX_your_org_key
    ```
 
 3. Deploy via docker-compose (see below)
@@ -86,7 +84,7 @@ Restart Claude Desktop after editing the config. The 11 Brilliant tools will app
 
 ```bash
 # Set required env vars
-export CORTEX_API_KEY=bkai_XXXX_your_org_key
+export BRILLIANT_API_KEY=bkai_XXXX_your_org_key
 export MCP_BASE_URL=http://localhost:8011  # or your deployed URL
 
 # Start all services
@@ -192,7 +190,7 @@ your-domain.example.com {
 
 ```bash
 # Stdio transport (against live API)
-CORTEX_API_KEY=bkai_adm1_testkey_admin python test_tools.py
+BRILLIANT_API_KEY=bkai_adm1_testkey_admin python test_tools.py
 
 # Remote transport (start server first, or use docker-compose)
 MCP_TEST_URL=http://localhost:8011 python test_remote.py

--- a/mcp/client.py
+++ b/mcp/client.py
@@ -5,12 +5,12 @@ import os
 import httpx
 
 
-class CortexClient:
+class BrilliantClient:
     """Async HTTP client for the Brilliant REST API."""
 
     def __init__(self):
-        self.base_url = os.environ.get("CORTEX_BASE_URL", "http://localhost:8010").rstrip("/")
-        self.api_key = os.environ.get("CORTEX_API_KEY", "")
+        self.base_url = os.environ.get("BRILLIANT_BASE_URL", "http://localhost:8010").rstrip("/")
+        self.api_key = os.environ.get("BRILLIANT_API_KEY", "")
 
     def _headers(self, api_key: str | None = None) -> dict[str, str]:
         """Build request headers, optionally overriding the default API key."""

--- a/mcp/oauth_store.py
+++ b/mcp/oauth_store.py
@@ -13,11 +13,11 @@ from psycopg.rows import dict_row
 from mcp.server.auth.provider import AccessToken, AuthorizationCode, RefreshToken
 from mcp.shared.auth import OAuthClientInformationFull
 
-logger = logging.getLogger("cortex.oauth_store")
+logger = logging.getLogger("brilliant.oauth_store")
 
 DATABASE_URL = os.getenv(
     "DATABASE_URL",
-    "postgresql://postgres:dev@localhost:5432/cortex",
+    "postgresql://postgres:dev@localhost:5432/brilliant",
 )
 
 

--- a/mcp/remote_server.py
+++ b/mcp/remote_server.py
@@ -19,11 +19,11 @@ from mcp.server.fastmcp import FastMCP
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
 from starlette.middleware.cors import CORSMiddleware
 
-from client import CortexClient
+from client import BrilliantClient
 from oauth_store import PgOAuthStore
 from tools import register_tools
 
-logger = logging.getLogger("cortex.auth")
+logger = logging.getLogger("brilliant.auth")
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -31,7 +31,7 @@ logger = logging.getLogger("cortex.auth")
 
 MCP_PORT = int(os.environ.get("MCP_PORT", "8001"))
 MCP_BASE_URL = os.environ.get("MCP_BASE_URL", "http://localhost:8011")
-CORTEX_API_KEY = os.environ.get("CORTEX_API_KEY", "")
+BRILLIANT_API_KEY = os.environ.get("BRILLIANT_API_KEY", "")
 TOKEN_EXPIRY_SECONDS = int(os.environ.get("TOKEN_EXPIRY_SECONDS", "3600"))
 
 
@@ -40,7 +40,7 @@ TOKEN_EXPIRY_SECONDS = int(os.environ.get("TOKEN_EXPIRY_SECONDS", "3600"))
 # ---------------------------------------------------------------------------
 
 
-class CortexOAuthProvider(OAuthAuthorizationServerProvider[AuthorizationCode, RefreshToken, AccessToken]):
+class BrilliantOAuthProvider(OAuthAuthorizationServerProvider[AuthorizationCode, RefreshToken, AccessToken]):
     """OAuth 2.1 provider for Claude Co-work integration.
 
     Supports Dynamic Client Registration (DCR) so Co-work can self-register,
@@ -55,7 +55,7 @@ class CortexOAuthProvider(OAuthAuthorizationServerProvider[AuthorizationCode, Re
         return await self.store.get_client(client_id)
 
     async def register_client(self, client_info: OAuthClientInformationFull) -> None:
-        client_id = f"cortex_{secrets.token_hex(16)}"
+        client_id = f"brilliant_{secrets.token_hex(16)}"
         client_secret = secrets.token_hex(32)
         client_info.client_id = client_id
         client_info.client_secret = client_secret
@@ -185,10 +185,10 @@ class CortexOAuthProvider(OAuthAuthorizationServerProvider[AuthorizationCode, Re
 # ---------------------------------------------------------------------------
 
 store = PgOAuthStore()
-provider = CortexOAuthProvider(store)
+provider = BrilliantOAuthProvider(store)
 
 mcp = FastMCP(
-    name="cortex",
+    name="brilliant",
     host="0.0.0.0",
     port=MCP_PORT,
     auth_server_provider=provider,
@@ -197,8 +197,8 @@ mcp = FastMCP(
         resource_server_url=MCP_BASE_URL,
         client_registration_options=ClientRegistrationOptions(
             enabled=True,
-            valid_scopes=["cortex"],
-            default_scopes=["cortex"],
+            valid_scopes=["brilliant"],
+            default_scopes=["brilliant"],
         ),
         revocation_options=RevocationOptions(enabled=True),
         required_scopes=[],
@@ -210,7 +210,7 @@ mcp.settings.debug = False
 mcp._custom_starlette_routes = getattr(mcp, "_custom_starlette_routes", [])
 
 # Register all 11 Brilliant tools
-api = CortexClient()
+api = BrilliantClient()
 register_tools(mcp, api)
 
 

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from mcp.server.fastmcp import FastMCP
 
-from client import CortexClient
+from client import BrilliantClient
 from tools import register_tools
 
-mcp = FastMCP(name="cortex")
-api = CortexClient()
+mcp = FastMCP(name="brilliant")
+api = BrilliantClient()
 register_tools(mcp, api)
 
 

--- a/mcp/test_tools.py
+++ b/mcp/test_tools.py
@@ -6,9 +6,9 @@ import sys
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from client import CortexClient
+from client import BrilliantClient
 
-api = CortexClient()
+api = BrilliantClient()
 
 passed = 0
 failed = 0

--- a/mcp/tools.py
+++ b/mcp/tools.py
@@ -8,10 +8,10 @@ from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
-from client import CortexClient
+from client import BrilliantClient
 
 
-def register_tools(mcp: FastMCP, api: CortexClient) -> None:
+def register_tools(mcp: FastMCP, api: BrilliantClient) -> None:
     """Register all 18 Brilliant tools on the given FastMCP server instance."""
 
     # -------------------------------------------------------------------
@@ -559,9 +559,9 @@ def register_tools(mcp: FastMCP, api: CortexClient) -> None:
     # -------------------------------------------------------------------
 
     def _coerce_admin_error(result: dict) -> dict:
-        """Convert a raw 403 CortexClient error dict into the documented shape.
+        """Convert a raw 403 BrilliantClient error dict into the documented shape.
 
-        CortexClient returns {"error": True, "status": 403, "detail": ...} on
+        BrilliantClient returns {"error": True, "status": 403, "detail": ...} on
         HTTP 4xx/5xx. For admin-only endpoints we surface a friendlier
         {"error": "admin-only", "detail": ...} so non-admin callers never see
         a raw exception or a generic error envelope.

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -63,10 +63,10 @@ except ImportError:  # pragma: no cover
 # Configuration — worktree-specific defaults (API :8020, DB :5452)
 # ----------------------------------------------------------------------------
 
-BASE_URL = os.environ.get("CORTEX_BASE_URL", "http://localhost:8020")
+BASE_URL = os.environ.get("BRILLIANT_BASE_URL", "http://localhost:8020")
 DB_DSN = os.environ.get(
-    "CORTEX_DB_DSN",
-    "postgresql://postgres:dev@localhost:5452/cortex",
+    "BRILLIANT_DB_DSN",
+    "postgresql://postgres:dev@localhost:5452/brilliant",
 )
 
 # Admin key from db/migrations/005_seed.sql — same one used by test_pdf_digest.

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -48,10 +48,10 @@ except ImportError:
 # Configuration
 # ---------------------------------------------------------------------------
 
-BASE_URL = os.environ.get("CORTEX_BASE_URL", "http://localhost:8010")
+BASE_URL = os.environ.get("BRILLIANT_BASE_URL", "http://localhost:8010")
 DB_DSN = os.environ.get(
-    "CORTEX_DB_DSN",
-    "postgresql://postgres:dev@localhost:5442/cortex",
+    "BRILLIANT_DB_DSN",
+    "postgresql://postgres:dev@localhost:5442/brilliant",
 )
 
 # Test API keys from db/migrations/005_seed.sql.

--- a/tests/test_entries_render.py
+++ b/tests/test_entries_render.py
@@ -37,16 +37,16 @@ except ImportError:
 # Configuration
 # ---------------------------------------------------------------------------
 
-BASE_URL = os.environ.get("CORTEX_BASE_URL", "http://localhost:8010")
+BASE_URL = os.environ.get("BRILLIANT_BASE_URL", "http://localhost:8010")
 DB_DSN = os.environ.get(
-    "CORTEX_DB_DSN",
-    "postgresql://postgres:dev@localhost:5442/cortex",
+    "BRILLIANT_DB_DSN",
+    "postgresql://postgres:dev@localhost:5442/brilliant",
 )
 
 # Seed API key + user id (see db/migrations/005_seed.sql).
 ADMIN_KEY = "bkai_adm1_testkey_admin"
 USR_ADMIN = "usr_admin"
-ORG_ID = os.environ.get("CORTEX_TEST_ORG_ID", "org_demo")  # seeded org
+ORG_ID = os.environ.get("BRILLIANT_TEST_ORG_ID", "org_demo")  # seeded org
 
 REQUEST_TIMEOUT = 10.0
 

--- a/tests/test_entries_write.py
+++ b/tests/test_entries_write.py
@@ -27,10 +27,10 @@ except ImportError:
     _PSYCOPG_AVAILABLE = False
 
 
-BASE_URL = os.environ.get("CORTEX_BASE_URL", "http://localhost:8010")
+BASE_URL = os.environ.get("BRILLIANT_BASE_URL", "http://localhost:8010")
 DB_DSN = os.environ.get(
-    "CORTEX_DB_DSN",
-    "postgresql://postgres:dev@localhost:5442/cortex",
+    "BRILLIANT_DB_DSN",
+    "postgresql://postgres:dev@localhost:5442/brilliant",
 )
 ADMIN_KEY = "bkai_adm1_testkey_admin"
 REQUEST_TIMEOUT = 10.0

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -16,8 +16,8 @@ Run:
   pytest tests/test_observability.py -v
 
 Env overrides (keep tests runnable from either worktree after merge):
-  CORTEX_BASE_URL  -- default http://localhost:8030
-  CORTEX_DB_DSN    -- default postgresql://postgres:dev@localhost:5462/cortex
+  BRILLIANT_BASE_URL  -- default http://localhost:8030
+  BRILLIANT_DB_DSN    -- default postgresql://postgres:dev@localhost:5462/brilliant
 """
 
 from __future__ import annotations
@@ -40,10 +40,10 @@ except ImportError:
 # 8010/:5442. Default to the observability ports so this file works without
 # env overrides when executed from this worktree, but allow override so the
 # same tests can run from the primary tree after merge.
-BASE_URL = os.environ.get("CORTEX_BASE_URL", "http://localhost:8030")
+BASE_URL = os.environ.get("BRILLIANT_BASE_URL", "http://localhost:8030")
 DB_DSN = os.environ.get(
-    "CORTEX_DB_DSN",
-    "postgresql://postgres:dev@localhost:5462/cortex",
+    "BRILLIANT_DB_DSN",
+    "postgresql://postgres:dev@localhost:5462/brilliant",
 )
 
 ADMIN_KEY = "bkai_adm1_testkey_admin"

--- a/tests/test_pdf_digest.py
+++ b/tests/test_pdf_digest.py
@@ -65,10 +65,10 @@ except ImportError:  # pragma: no cover
     _PSYCOPG_AVAILABLE = False
 
 
-BASE_URL = os.environ.get("CORTEX_BASE_URL", "http://localhost:8020")
+BASE_URL = os.environ.get("BRILLIANT_BASE_URL", "http://localhost:8020")
 DB_DSN = os.environ.get(
-    "CORTEX_DB_DSN",
-    "postgresql://postgres:dev@localhost:5452/cortex",
+    "BRILLIANT_DB_DSN",
+    "postgresql://postgres:dev@localhost:5452/brilliant",
 )
 ADMIN_KEY = os.environ.get("ADMIN_KEY", "bkai_adm1_testkey_admin")
 

--- a/tests/test_permissions_v2.py
+++ b/tests/test_permissions_v2.py
@@ -52,10 +52,10 @@ except ImportError:
 # Configuration (mirrors tests/test_comments.py)
 # ---------------------------------------------------------------------------
 
-BASE_URL = os.environ.get("CORTEX_BASE_URL", "http://localhost:8010")
+BASE_URL = os.environ.get("BRILLIANT_BASE_URL", "http://localhost:8010")
 DB_DSN = os.environ.get(
-    "CORTEX_DB_DSN",
-    "postgresql://postgres:dev@localhost:5442/cortex",
+    "BRILLIANT_DB_DSN",
+    "postgresql://postgres:dev@localhost:5442/brilliant",
 )
 
 # Test API keys from db/migrations/005_seed.sql.

--- a/tests/test_staging.py
+++ b/tests/test_staging.py
@@ -23,7 +23,7 @@ import pytest
 import requests
 
 
-BASE_URL = os.environ.get("CORTEX_BASE_URL", "http://localhost:8010")
+BASE_URL = os.environ.get("BRILLIANT_BASE_URL", "http://localhost:8010")
 ADMIN_KEY = "bkai_adm1_testkey_admin"
 REQUEST_TIMEOUT = 10.0
 


### PR DESCRIPTION
## Summary
- Renames Cortex → Brilliant across containers, default DB (`POSTGRES_DB=brilliant`), env vars (`CORTEX_*` → `BRILLIANT_*`), MCP client class (`BrilliantClient`), OAuth scope, GHCR image names, and logger names.
- Clean break on env vars — no carve-out. Breaking change for v0.3.0 release notes.
- Adds `install.sh --migrate-from-cortex`: stops cortex-api/mcp, runs `ALTER DATABASE cortex RENAME TO brilliant`, removes cortex containers (data volume preserved), rebuilds as brilliant-*, health-checks.
- Relaxes installer's bash guard from 4+ to 3.2+ (no bash-4-only features used; allows macOS dev boxes).

## Validation
- Spec AC1 grep clean except two intentional exceptions: `install.sh` migrate helper (must know old names) + `CortexDB` demo seed text.
- Local `--migrate-from-cortex --dry-run` then real run: 695 entries preserved, `/health` 200, only `brilliant-*` containers, zero `cortex` strings in `docker compose logs`.
- CI fresh-install smoke (Path 2) remains covered by `installer-smoke.yml` on ubuntu-22.04.

## Test plan
- [ ] CI installer-smoke passes
- [ ] Staging deploy with `--migrate-from-cortex` preserves row counts; `/health`, `/entries`, observability, attachments endpoints respond
- [ ] No `cortex-*` containers on staging post-migration
- [ ] v0.3.0 breaking-change notes mention container/DB rename, env-var rename, MCP OAuth scope rename, deprecated `cortex-*` GHCR images

🤖 Generated with [Claude Code](https://claude.com/claude-code)