### PR TITLE
fix: widen api docker-context for Render preDeploy (T-0222)

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.12-slim
 WORKDIR /app
-COPY requirements.txt .
+COPY api/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY . .
+COPY api/ ./
+COPY tools/ ./tools/
+COPY db/migrations/ ./db/migrations/
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,9 @@ services:
       retries: 5
 
   api:
-    build: ./api
+    build:
+      context: .
+      dockerfile: ./api/Dockerfile
     container_name: brilliant-api
     depends_on:
       db:

--- a/render.yaml
+++ b/render.yaml
@@ -38,7 +38,7 @@ services:
     plan: starter
     region: oregon
     dockerfilePath: ./api/Dockerfile
-    dockerContext: ./api
+    dockerContext: .
     # Override the Dockerfile CMD to drop `--reload` in production.
     startCommand: uvicorn main:app --host 0.0.0.0 --port 8000
     # Runs before every deploy (Render executes this inside the built


### PR DESCRIPTION
## Summary

- Widens the `brilliant-api` Docker build context so `tools/render_migrate.py` and `db/migrations/*.sql` land in the image — Render's `preDeployCommand: python tools/render_migrate.py` was guaranteed to fail without this.
- `api/Dockerfile` now copies `api/`, `tools/`, and `db/migrations/` from repo-root context.
- `render.yaml` flips `brilliant-api.dockerContext` from `./api` to `.`.
- `docker-compose.yml` api service switched to root context w/ explicit `dockerfile: ./api/Dockerfile` so local dev keeps working with the new layout.

Unblocks **T-0219** (Render wet-test) → **v0.4.0** tag.

## Test plan

- [x] `docker build -f api/Dockerfile -t brilliant-api-test .` — image contains `/app/main.py`, `/app/tools/render_migrate.py`, `/app/db/migrations/027_first_run_flag.sql`
- [x] `docker compose up -d --build` — local stack healthy, `curl http://localhost:8010/health` → `{"status":"ok"}`
- [x] Parallel-stack pytest (`COMPOSE_PROJECT_NAME=brilliant-test`, ports 9010/9011/5543) — **114 passed, 6 skipped, 2 deselected**; no regressions vs T-0211 baseline (115/5/2)
- [ ] T-0219 wet-test on throwaway Render account (human step, blocked until this merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)