### PR TITLE
docs: README hero — landing-page branding + colored title

### DIFF
--- a/.github/assets/title-dark.svg
+++ b/.github/assets/title-dark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 72" role="img" aria-label="xiReactor / Brilliant">
+  <text x="0" y="54" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="56" font-weight="700" letter-spacing="-1.2">
+    <tspan fill="#6b7aff">xi</tspan><tspan fill="#e6edf3">Reactor / </tspan><tspan fill="#6b7aff">Brilliant</tspan>
+  </text>
+</svg>

--- a/.github/assets/title-light.svg
+++ b/.github/assets/title-light.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 72" role="img" aria-label="xiReactor / Brilliant">
+  <text x="0" y="54" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="56" font-weight="700" letter-spacing="-1.2">
+    <tspan fill="#4558c9">xi</tspan><tspan fill="#1f2328">Reactor / </tspan><tspan fill="#4558c9">Brilliant</tspan>
+  </text>
+</svg>

--- a/README.md
+++ b/README.md
@@ -2,10 +2,19 @@
   <img src=".github/assets/logo.svg" width="140" alt="Brilliant logo" />
 </p>
 
-<h1 align="center">xiReactor Brilliant</h1>
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset=".github/assets/title-dark.svg">
+    <img src=".github/assets/title-light.svg" width="520" alt="xiReactor / Brilliant" />
+  </picture>
+</p>
+
+<h2 align="center">One shared knowledge base for your whole AI-enabled team</h2>
 
 <p align="center">
-  <strong>Shared context that compounds.</strong>
+  Your people and your agents — reading, writing, and growing the same knowledge base,<br/>
+  with governance and permissions built in. Every conversation, decision, and document<br/>
+  compounds into leverage your team keeps from day one.
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- New `.github/assets/title-{light,dark}.svg` renders the title with real brand colors (GitHub strips inline `style` from README HTML, so SVG is the only reliable path). "xi" and "Brilliant" in brand blue (`#4558c9` light / `#6b7aff` dark); "Reactor / " in theme-neutral text; swapped via `<picture>` + `prefers-color-scheme`.
- Replaces `<h1>xiReactor Brilliant</h1>` with the picture block.
- Hero copy now mirrors the landing page:
  - New subtitle: **"One shared knowledge base for your whole AI-enabled team"**
  - New supporting paragraph on agents + governance + compounding leverage

Doc-only — no code paths touched.

## Test plan

- [x] `<picture>` block renders the right SVG per GitHub theme (light vs dark)
- [ ] Visual sanity-check once merged and rendered on the repo landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)