### PR TITLE
docs: center title text within the SVG viewBox

### DIFF
--- a/.github/assets/title-dark.svg
+++ b/.github/assets/title-dark.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 72" role="img" aria-label="xiReactor / Brilliant">
-  <text x="0" y="54" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="56" font-weight="700" letter-spacing="-1.2">
+  <text x="260" y="54" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="56" font-weight="700" letter-spacing="-1.2">
     <tspan fill="#6b7aff">xi</tspan><tspan fill="#e6edf3">Reactor / </tspan><tspan fill="#6b7aff">Brilliant</tspan>
   </text>
 </svg>

--- a/.github/assets/title-light.svg
+++ b/.github/assets/title-light.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 72" role="img" aria-label="xiReactor / Brilliant">
-  <text x="0" y="54" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="56" font-weight="700" letter-spacing="-1.2">
+  <text x="260" y="54" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="56" font-weight="700" letter-spacing="-1.2">
     <tspan fill="#4558c9">xi</tspan><tspan fill="#1f2328">Reactor / </tspan><tspan fill="#4558c9">Brilliant</tspan>
   </text>
 </svg>


### PR DESCRIPTION
One-line fix on both title SVGs — `text-anchor="middle"` at `x=260` so the text centers within its canvas instead of left-aligning and leaving blank padding on the right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)