### PR TITLE
docs: pin title SVG width to the actual text extent

### DIFF
--- a/.github/assets/title-dark.svg
+++ b/.github/assets/title-dark.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 72" role="img" aria-label="xiReactor / Brilliant">
-  <text x="260" y="54" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="56" font-weight="700" letter-spacing="-1.2">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 440 72" role="img" aria-label="xiReactor / Brilliant">
+  <text x="220" y="54" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="56" font-weight="700" letter-spacing="-1.2" textLength="420" lengthAdjust="spacingAndGlyphs">
     <tspan fill="#6b7aff">xi</tspan><tspan fill="#e6edf3">Reactor / </tspan><tspan fill="#6b7aff">Brilliant</tspan>
   </text>
 </svg>

--- a/.github/assets/title-light.svg
+++ b/.github/assets/title-light.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 72" role="img" aria-label="xiReactor / Brilliant">
-  <text x="260" y="54" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="56" font-weight="700" letter-spacing="-1.2">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 440 72" role="img" aria-label="xiReactor / Brilliant">
+  <text x="220" y="54" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="56" font-weight="700" letter-spacing="-1.2" textLength="420" lengthAdjust="spacingAndGlyphs">
     <tspan fill="#4558c9">xi</tspan><tspan fill="#1f2328">Reactor / </tspan><tspan fill="#4558c9">Brilliant</tspan>
   </text>
 </svg>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset=".github/assets/title-dark.svg">
-    <img src=".github/assets/title-light.svg" width="520" alt="xiReactor / Brilliant" />
+    <img src=".github/assets/title-light.svg" width="440" alt="xiReactor / Brilliant" />
   </picture>
 </p>
 


### PR DESCRIPTION
Tightens the title SVG viewBox from 520x72 to 440x72 and adds `textLength=420` + `lengthAdjust=spacingAndGlyphs` so the text fits the canvas exactly, eliminating the visible right-side slack reported in the rendered README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)