### PR TITLE
Sprint 0043 + 0044: installer fixes + /setup unification (v0.5.1)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -43,11 +43,17 @@ BRILLIANT_DB_PORT=5442
 BRILLIANT_API_PORT=8010
 BRILLIANT_MCP_PORT=8011
 
-# --- Admin bootstrap (REQUIRED on first run) ---
-# The first time the API starts against an empty DB, these create the
-# admin user. Set them once, then you can unset them if you prefer.
-ADMIN_EMAIL=admin@example.com
-ADMIN_PASSWORD=change-me-before-first-run
+# --- Admin bootstrap (OPTIONAL — headless install only) ---
+# Sprint 0044 T-0260 — the default install path is the `/setup` web
+# ceremony: no admin user exists until the operator completes the form.
+# These env vars are only consumed when `install.sh` is invoked with
+# `--admin-email` + `--admin-password` (the headless / VPS / CI path).
+# Setting them here without invoking the installer that way still works
+# (FastAPI's admin_bootstrap reads them at first boot), but you'll lose
+# the auto-written `./brilliant-credentials.txt` that the installer
+# produces on the headless path.
+# ADMIN_EMAIL=admin@example.com
+# ADMIN_PASSWORD=change-me-before-first-run
 # ADMIN_API_KEY=  # optional — if unset, one is auto-generated and logged at startup
 
 # --- Tier 3 AI reviewer (OPTIONAL) ---

--- a/.env.sample
+++ b/.env.sample
@@ -28,6 +28,21 @@ MCP_BASE_URL=http://localhost:8011
 MCP_PORT=8001
 TOKEN_EXPIRY_SECONDS=3600
 
+# --- API server public URL (consumed by admin_bootstrap.py for the
+#     installer's credentials-file `login_url` field). Mirrors the host
+#     port advertised by BRILLIANT_API_PORT below. ---
+API_BASE_URL=http://localhost:8010
+
+# --- Host port bindings (Sprint 0043 T-0257) ---
+# docker-compose.yml reads these to map container ports to host ports.
+# install.sh runs a port-probe at phase 4b; if any of these ports is
+# occupied it picks the next free +10 step (e.g. 5442→5452) and
+# overwrites these values before `docker compose up`. On a clean
+# machine these are no-ops; override manually to pin specific ports.
+BRILLIANT_DB_PORT=5442
+BRILLIANT_API_PORT=8010
+BRILLIANT_MCP_PORT=8011
+
 # --- Admin bootstrap (REQUIRED on first run) ---
 # The first time the API starts against an empty DB, these create the
 # admin user. Set them once, then you can unset them if you prefer.

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -54,16 +54,29 @@ jobs:
           set -euo pipefail
           SCRATCH="$(mktemp -d)"
           cd "$SCRATCH"
+          # Sprint 0044 T-0260/T-0261 — default (browser-ceremony) path:
+          # no --admin-email (would shift this into the headless-with-admin
+          # branch), no --key-out (flag removed). The smoke job drives the
+          # POST /setup ceremony itself, mirroring what an operator's
+          # browser would do.
           bash "$GITHUB_WORKSPACE/install.sh" \
             --ref "$SELF_CLONE_REF" \
             --dir ./clone \
-            --admin-email smoke-selfclone@example.com \
-            --force \
-            --key-out /tmp/self-clone-key.txt
-          test -f /tmp/self-clone-key.txt
+            --force
           test -d "$SCRATCH/clone/.git"
           curl -fsS http://localhost:8010/health >/dev/null
-          key="$(cat /tmp/self-clone-key.txt)"
+          # POST /setup to claim the admin latch and pull credentials out
+          # of the response body. The /setup HTML response includes the
+          # plaintext admin API key (bkai_…) exactly once.
+          curl -fsS -X POST http://localhost:8010/setup \
+            -d 'org_name=Smoke&email=smoke@example.com&password=TestPass123&password_confirm=TestPass123' \
+            -o /tmp/response.html
+          key="$(grep -oE 'bkai_[a-f0-9_]+' /tmp/response.html | head -1)"
+          if [ -z "$key" ]; then
+            echo "FAIL: could not extract bkai_ admin key from /setup response"
+            head -n 50 /tmp/response.html || true
+            exit 14
+          fi
           code="$(curl -s -o /dev/null -w '%{http_code}' \
             -H "Authorization: Bearer ${key}" \
             http://localhost:8010/entries)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,31 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/
 ### Fixed
 - _nothing yet_
 
+## [0.5.1] — 2026-04-20 — Installer + Render unified on `/setup` web ceremony
+
+> **Breaking change:** `--key-out` removed from `install.sh`. The default install path no longer writes a credentials file to disk — the `/setup` web ceremony is the single source of truth, and `brilliant-credentials.txt` is delivered as a browser download from the response page. CI / scripted installs use the new headless install path (`--admin-email` + `--admin-password`), which env-bootstraps the admin and auto-writes `./brilliant-credentials.txt` after health-check.
+
+### Added
+- Unified installer + Render on the `/setup` web ceremony (closes [#46](https://github.com/thejeremyhodge/xireactor-brilliant/issues/46) and [#47](https://github.com/thejeremyhodge/xireactor-brilliant/issues/47)). The installer no longer env-bootstraps admin on the default path; the operator drives the same browser-based ceremony Render users see.
+- Browser auto-open on default install (macOS `open` / Linux `xdg-open` with URL-print fallback when neither binary is available). Failures never block the installer.
+- New `--headless` / `--no-browser` flag for VPS / CI / SSH-tunnel users — skips the browser auto-open and prints the `/setup` URL prominently with an SSH-tunnel hint (`ssh -L 8010:localhost:8010 user@host`).
+- New interactive password prompt when `--admin-email` is passed without `--admin-password` on a TTY — `read -s` with double-entry confirm; the password never appears in `ps` output or shell history.
+- Headless install with `--admin-email` + `--admin-password` auto-writes `./brilliant-credentials.txt` (mode 600, six fields) after health-check by curling `GET /credentials` with the minted admin key — no manual recovery `curl` required.
+
+### Changed
+- **BREAKING:** `--key-out` removed from `install.sh`; `KEY_OUT` / `DEFAULT_KEY_OUT` / `write_key_out` / `extract_credentials_block` / `absolutize_path` / `phase_verify` / `rand_password` deleted entirely. No installer-written credentials file on the default path.
+- `--admin-email` is no longer required on the default install path; the installer runs flag-free and points the operator at `/setup`. `--admin-email` / `--admin-password` now describe the headless install path explicitly in `--help`.
+- `--admin-password` on argv emits a one-line stderr warning ("password visible in `ps`/shell history — prefer interactive entry") but continues — CI-friendly escape valve.
+- `--admin-email` implies `--headless` (no browser opens when admin is being claimed via env bootstrap).
+- `phase_summary` banner reshaped into three branches: default (browser auto-open + `/setup` CTA), headless-no-admin (URL + SSH-tunnel hint), headless-with-admin (auto-written credentials file + `/credentials` re-fetch hint).
+- `.env.sample` — `ADMIN_EMAIL` / `ADMIN_PASSWORD` commented out with a note that they're now the headless install escape hatch.
+- README install section rewritten around the browser-auto-open + `/setup` flow; new "Headless install (VPS / CI / scripted)" subsection documents both the `--headless` SSH-tunnel and `--admin-email` / `--admin-password` scripted variants.
+- All Sprint 0043 polish (T-0253..T-0259) carried forward unchanged except the six-field credentials file composition: now either a browser deliverable (default path) or an installer-side `/credentials` fetch (headless-with-admin path).
+
+### Fixed
+- Installer banner pointing at `/setup` while the env-driven admin bootstrap had already claimed the latch (404 on click) — eliminated by removing the env-bootstrap path from the default install. Both lanes now share one ceremony.
+- Auto-generated admin password buried in `.env` and nowhere else — eliminated by removing the auto-generated password entirely. The operator either chooses the password in the `/setup` form (default) or supplies it interactively / on argv (headless).
+
 ## [0.5.0] — 2026-04-18 — OAuth user-bound authentication
 
 > **Breaking change:** Dynamic Client Registration on the MCP server is disabled. Every existing Claude Co-work connector must be re-provisioned with the `client_id` + `client_secret` shown on `/setup/done` (or recovered via `/auth/login`). Operators self-hosting before this release should treat `/setup` as a one-time reset surface after upgrading.
@@ -196,7 +221,8 @@ traversal via recursive CTEs, multi-tenant organizations with row-level security
 MCP integration for Claude Co-work and Claude Code (stdio + Streamable HTTP / OAuth 2.1),
 and Obsidian vault import with preview, collision detection, and batch rollback.
 
-[Unreleased]: https://github.com/thejeremyhodge/xireactor-brilliant/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/thejeremyhodge/xireactor-brilliant/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/thejeremyhodge/xireactor-brilliant/compare/v0.5.0...v0.5.1
 [0.3.0]: https://github.com/thejeremyhodge/xireactor-brilliant/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/thejeremyhodge/xireactor-brilliant/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/thejeremyhodge/xireactor-brilliant/compare/v0.2.0...v0.2.1

--- a/README.md
+++ b/README.md
@@ -85,16 +85,16 @@ Pipe the installer into `bash` from any directory — it will detect that it isn
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/thejeremyhodge/xireactor-brilliant/main/install.sh \
-  | bash -s -- --admin-email you@example.com
+  | bash
 ```
 
-The installer prints a phased plan, stands the stack up, and finishes with a summary banner containing your admin API key. The same key is written to `./brilliant-credentials.txt` (mode 600, inside the cloned directory).
+The installer stands up the stack and opens `/setup` in your browser; complete the form and download `brilliant-credentials.txt` from the response page. No credentials file is written by the installer on this default path — the browser download is the single source of truth.
 
 To pin a specific version or track `main`, pass `--ref`:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/thejeremyhodge/xireactor-brilliant/main/install.sh \
-  | bash -s -- --admin-email you@example.com --ref v0.5.0
+  | bash -s -- --ref v0.5.1
 ```
 
 To pick a different clone target, pass `--dir /path/to/target`.
@@ -106,13 +106,13 @@ If you prefer to inspect the repo before running anything, clone it first. When 
 ```bash
 git clone https://github.com/thejeremyhodge/xireactor-brilliant.git
 cd xireactor-brilliant
-./install.sh --admin-email you@example.com
+./install.sh
 ```
 
 Dry-run the plan first if you want to see what it will do:
 
 ```bash
-./install.sh --dry-run --admin-email you@example.com
+./install.sh --dry-run
 ```
 
 All flags:
@@ -121,10 +121,63 @@ All flags:
 ./install.sh --help
 ```
 
-### First API call
+### Headless install (VPS / CI / scripted)
+
+When the installer is running on a host without a desktop browser — a VPS, a CI runner, or any "remote shell" environment — you have two paths.
+
+**SSH-tunnel variant (recommended for VPS operators with a workstation browser):**
 
 ```bash
-curl -H "Authorization: Bearer $(cat ./brilliant-credentials.txt)" \
+./install.sh --headless
+```
+
+The installer skips the browser auto-open, stands up the stack, and prints the `/setup` URL prominently along with an SSH-tunnel hint. Forward the API port from your workstation:
+
+```bash
+ssh -L 8010:localhost:8010 user@your-vps-host
+```
+
+…then open `http://localhost:8010/setup` in your workstation browser and complete the same ceremony as the default install. Download `brilliant-credentials.txt` from the response page.
+
+**Scripted variant (CI / fully unattended):**
+
+```bash
+# Recommended: interactive password prompt (TTY only).
+./install.sh --admin-email you@example.com
+# Installer prompts for password twice (read -s, no echo).
+```
+
+When `--admin-email` is passed without `--admin-password`, the installer prompts interactively on a TTY (double-entry confirm). After health-check, the installer auto-curls `GET /credentials` with the minted admin key and writes `./brilliant-credentials.txt` (mode 600, six fields) — no manual recovery curl required, no browser opens.
+
+For fully unattended CI runs where no TTY is available, pass the password on argv (CI-only escape valve):
+
+```bash
+./install.sh --admin-email you@example.com --admin-password 'CHANGE_ME'
+```
+
+The installer emits a one-line stderr warning that `--admin-password` is visible in `ps`/shell history; prefer the interactive form whenever a TTY is available. The credentials file is written exactly the same way.
+
+If the `./brilliant-credentials.txt` write ever fails (or if you lose the file), re-fetch it any time with:
+
+```bash
+curl -H 'Authorization: Bearer YOUR_ADMIN_API_KEY' \
+  http://localhost:8010/credentials > brilliant-credentials.txt
+```
+
+### First API call
+
+After completing `/setup` in your browser, copy the API key from the downloaded `brilliant-credentials.txt` (default location: `~/Downloads/brilliant-credentials.txt`) and call the API:
+
+```bash
+# After /setup, copy the API key from brilliant-credentials.txt:
+curl -H "Authorization: Bearer YOUR_ADMIN_API_KEY" \
+  http://localhost:8010/entries
+```
+
+If you have the file at a known path, you can extract the key inline:
+
+```bash
+curl -H "Authorization: Bearer $(grep '^admin_api_key=' ~/Downloads/brilliant-credentials.txt | cut -d= -f2)" \
   http://localhost:8010/entries
 ```
 

--- a/api/admin_bootstrap.py
+++ b/api/admin_bootstrap.py
@@ -407,6 +407,36 @@ async def ensure_admin_user(pool) -> None:
         client_secret,
     )
 
+    # Sprint 0043 T-0253 — emit a machine-parseable credential block so
+    # install.sh can extract all six fields in one shot via
+    # `docker compose logs api` → grep between markers. Order matches the
+    # six-field contract documented in the spec:
+    #   admin_email, admin_api_key, oauth_client_id,
+    #   oauth_client_secret, mcp_url, login_url.
+    #
+    # The MCP_BASE_URL / API_BASE_URL env-var fallback structure is kept
+    # intentionally minimal here — T-0257 extends it to carry through the
+    # installer's port-probing output.
+    mcp_url = os.getenv("MCP_BASE_URL", "").strip() or "http://localhost:8011"
+    api_base = os.getenv("API_BASE_URL", "").strip() or "http://localhost:8010"
+    login_url = f"{api_base.rstrip('/')}/auth/login"
+    logger.warning(
+        "===BRILLIANT_CREDENTIALS_BEGIN===\n"
+        "admin_email=%s\n"
+        "admin_api_key=%s\n"
+        "oauth_client_id=%s\n"
+        "oauth_client_secret=%s\n"
+        "mcp_url=%s\n"
+        "login_url=%s\n"
+        "===BRILLIANT_CREDENTIALS_END===",
+        admin_email,
+        api_key_plaintext,
+        client_id,
+        client_secret,
+        mcp_url,
+        login_url,
+    )
+
 
 async def create_admin_via_post(
     pool, email: str, password: str, org_name: str = DEFAULT_ORG_NAME

--- a/api/routes/entries.py
+++ b/api/routes/entries.py
@@ -585,7 +585,7 @@ async def append_entry(
                 user.id,
                 user.source,
                 None,  # change_summary
-                "appended",  # governance_action
+                "updated",  # governance_action
             ),
         )
 

--- a/api/routes/import_files.py
+++ b/api/routes/import_files.py
@@ -1112,17 +1112,23 @@ def _render_vault_upload_page() -> str:
     Self-contained: zero external fetches (no CDN, no webfonts, no images).
     The page:
 
-    1. On load, checks ``localStorage.brilliant_api_key``. If present the
+    1. On load, checks ``window.location.hash`` for an ``#api_key=<key>``
+       fragment (handoff from the ``/setup`` Import Vault button, spec
+       0043 / T-0255). If present, writes the key to
+       ``localStorage.brilliant_api_key`` and clears the fragment via
+       ``history.replaceState`` so the secret does not survive into the
+       visible URL / back-nav / copy-paste surface.
+    2. Then checks ``localStorage.brilliant_api_key``. If present the
        Bearer token is attached automatically to the POST; if absent, a
        password-style input renders with an optional "save in this browser"
        checkbox that writes the pasted key back to the same localStorage
        key so the next visit auto-populates.
-    2. On submit, POSTs multipart to ``/import/vault-upload`` with the
+    3. On submit, POSTs multipart to ``/import/vault-upload`` with the
        tarball file and optional ``source_vault`` / ``base_path`` /
        ``excludes`` fields.
-    3. On success, renders ``{created, staged, batch_id}`` inline plus a
+    4. On success, renders ``{created, staged, batch_id}`` inline plus a
        rollback hint pointing at the MCP ``rollback_import`` tool.
-    4. On HTTP error, renders the server's JSON ``detail`` verbatim — no
+    5. On HTTP error, renders the server's JSON ``detail`` verbatim — no
        generic fallback message.
     """
     # All JS lives in a single <script> block. Curly-braces intended for
@@ -1211,6 +1217,41 @@ def _render_vault_upload_page() -> str:
     var rememberInput = document.getElementById("remember");
     var submitBtn = document.getElementById("submit-btn");
     var resultPanel = document.getElementById("result");
+
+    // ----- URL-fragment handoff from /setup (spec 0043 / T-0255) -----
+    // The /setup credentials page renders an Import Obsidian vault
+    // button whose href carries the freshly-minted admin API key as a
+    // URL fragment (#api_key=...). Fragments never leave the browser,
+    // so the secret doesn't ride the wire to the server. We read it
+    // here, stuff it into localStorage so the form's fetch() can
+    // attach the Authorization header, populate the input field for
+    // operator visibility, and then replace history state so the
+    // fragment is scrubbed from the address bar / back-nav / copy-URL.
+    try {{
+      var rawHash = window.location.hash || "";
+      if (rawHash.length > 1) {{
+        var inner = rawHash.charAt(0) === "#" ? rawHash.slice(1) : rawHash;
+        var params = new URLSearchParams(inner);
+        var frag = params.get("api_key");
+        if (frag && frag.length > 0) {{
+          try {{
+            window.localStorage.setItem(STORAGE_KEY, frag);
+          }} catch (e) {{ /* localStorage disabled — continue with in-memory flow */ }}
+          if (apiKeyInput) {{
+            apiKeyInput.value = frag;
+          }}
+          // Strip the fragment from the visible URL. ``replaceState``
+          // does NOT trigger a navigation so the page state / form
+          // values are preserved.
+          if (window.history && typeof window.history.replaceState === "function") {{
+            window.history.replaceState(null, "", window.location.pathname + window.location.search);
+          }}
+        }}
+      }}
+    }} catch (e) {{
+      // URLSearchParams or history API unavailable — fall through to
+      // the normal localStorage / paste-your-key path.
+    }}
 
     var storedKey = null;
     try {{

--- a/api/routes/setup.py
+++ b/api/routes/setup.py
@@ -155,7 +155,8 @@ async def _mcp_url_for_display(pool) -> str:
     if not base:
         raw = os.getenv("BRILLIANT_MCP_PUBLIC_URL", "").strip()
         if not raw:
-            base = "http://localhost:8011"
+            port = os.getenv("BRILLIANT_MCP_PORT", "").strip() or "8011"
+            base = f"http://localhost:{port}"
         elif raw.startswith("http://") or raw.startswith("https://"):
             base = raw
         else:

--- a/api/routes/setup.py
+++ b/api/routes/setup.py
@@ -33,10 +33,11 @@ import html as _html
 import json as _json
 import os
 
-from fastapi import APIRouter, Form, HTTPException, Request
-from fastapi.responses import HTMLResponse
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse
 
 from admin_bootstrap import FirstRunAlreadyClaimed, create_admin_via_post
+from auth import UserContext, get_current_user
 from database import get_pool
 
 router = APIRouter(tags=["setup"])
@@ -173,6 +174,64 @@ async def _mcp_url_for_display(pool) -> str:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Brand assets — inlined SVGs
+# ---------------------------------------------------------------------------
+#
+# Inlined rather than served from /static/brand/* because (a) FastAPI has no
+# static mount configured today and (b) the SVGs are tiny (~2KB total). Keep
+# these in sync with .github/assets/logo.svg and .github/assets/title-light.svg
+# when the README brand mark is updated.
+
+_BRAND_LOGO_SVG = """<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Brilliant logo" class="brand-logo">
+  <defs>
+    <linearGradient id="gemEdge" gradientUnits="userSpaceOnUse" x1="50" y1="13" x2="50" y2="93">
+      <stop offset="0" stop-color="#8aa0ff"/>
+      <stop offset="1" stop-color="#4558c9"/>
+    </linearGradient>
+  </defs>
+  <polygon points="28,13 72,13 85,34 50,93 15,34" fill="none" stroke="#000000" stroke-width="5" stroke-linejoin="round"/>
+  <polygon points="28,13 72,13 85,34 50,93 15,34" fill="url(#gemEdge)" stroke="#ffffff" stroke-width="2.4" stroke-linejoin="round"/>
+  <g>
+    <polygon points="30,17 20,34 40,34" fill="#ffffff"/>
+    <polygon points="30,17 50,17 40,34" fill="url(#gemEdge)"/>
+    <polygon points="50,17 40,34 60,34" fill="#ffffff"/>
+    <polygon points="50,17 70,17 60,34" fill="url(#gemEdge)"/>
+    <polygon points="70,17 60,34 80,34" fill="#ffffff"/>
+    <polygon points="20,34 40,34 30,51" fill="url(#gemEdge)"/>
+    <polygon points="40,34 30,51 50,51" fill="#ffffff"/>
+    <polygon points="40,34 60,34 50,51" fill="url(#gemEdge)"/>
+    <polygon points="60,34 50,51 70,51" fill="#ffffff"/>
+    <polygon points="60,34 80,34 70,51" fill="url(#gemEdge)"/>
+    <polygon points="30,51 50,51 40,68" fill="url(#gemEdge)"/>
+    <polygon points="50,51 40,68 60,68" fill="#ffffff"/>
+    <polygon points="50,51 70,51 60,68" fill="url(#gemEdge)"/>
+    <polygon points="40,68 60,68 50,85" fill="url(#gemEdge)"/>
+  </g>
+</svg>"""
+
+_BRAND_TITLE_SVG = """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 72" role="img" aria-label="xiReactor / Brilliant" class="brand-title">
+  <text x="260" y="54" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="56" font-weight="700" letter-spacing="-1.2">
+    <tspan fill="#4558c9">xi</tspan><tspan fill="#1f2328">Reactor / </tspan><tspan fill="#4558c9">Brilliant</tspan>
+  </text>
+</svg>"""
+
+_BRAND_TAGLINE = "One shared knowledge base for your whole AI-enabled team"
+
+
+def _render_brand_header() -> str:
+    """Render the shared brand header: logo + title SVG + tagline.
+
+    Used by both ``/setup`` (pre-claim form) and the credentials page
+    (post-claim) so the first-run operator sees the same mark that appears
+    in the README. Purely presentational — no secrets or form fields.
+    """
+    return f"""<header class="brand-header" role="banner">
+    <div class="brand-mark">{_BRAND_LOGO_SVG}{_BRAND_TITLE_SVG}</div>
+    <p class="brand-tagline">{_html.escape(_BRAND_TAGLINE)}</p>
+  </header>"""
+
+
 _BASE_STYLE = """
   body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
          max-width: 560px; margin: 64px auto; padding: 0 16px; color: #111;
@@ -189,6 +248,11 @@ _BASE_STYLE = """
            border: 0; border-radius: 6px; cursor: pointer; margin-right: 8px; }
   button:hover { background: #333; }
   button.secondary { background: #fff; color: #111; border: 1px solid #111; }
+  a.button { display: inline-block; padding: 10px 14px; font-size: 1rem;
+             background: #111; color: #fff; border: 0; border-radius: 6px;
+             cursor: pointer; margin-right: 8px; text-decoration: none; }
+  a.button:hover { background: #333; }
+  a.button.secondary { background: #fff; color: #111; border: 1px solid #111; }
   .error { background: #fdecec; color: #8a1f1f; padding: 10px 12px;
            border-radius: 6px; border: 1px solid #f5b5b5; }
   .warn { background: #fff8e1; border: 1px solid #f0d878; color: #6b5200;
@@ -203,6 +267,34 @@ _BASE_STYLE = """
          padding: 10px 12px; border-radius: 6px; word-break: break-all;
          font-size: 0.95rem; }
   .actions { margin-top: 24px; }
+
+  /* Brand header — logo + title SVG + tagline, matches README brand mark. */
+  .brand-header { text-align: center; margin-bottom: 32px; }
+  .brand-mark { display: flex; align-items: center; justify-content: center;
+                gap: 14px; margin-bottom: 8px; }
+  .brand-logo { width: 56px; height: 56px; flex: 0 0 auto; }
+  .brand-title { height: 42px; width: auto; flex: 0 1 auto; max-width: 360px; }
+  .brand-tagline { color: #555; font-size: 0.95rem; margin: 0; }
+
+  /* Pulsing blue CTA for the credentials-download button. The CTA pulses
+   * until the operator clicks it (or explicitly checks the "I've saved"
+   * box) — at which point JS removes the .pulse class and the
+   * beforeunload guard is cleared. */
+  button.pulse { background: #2f5ad8; color: #fff;
+                 animation: brilliant-pulse 1.8s ease-in-out infinite;
+                 box-shadow: 0 0 0 0 rgba(47, 90, 216, 0.7); }
+  button.pulse:hover { background: #1f48c2; }
+  @keyframes brilliant-pulse {
+    0%   { box-shadow: 0 0 0 0 rgba(47, 90, 216, 0.55); }
+    70%  { box-shadow: 0 0 0 14px rgba(47, 90, 216, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(47, 90, 216, 0); }
+  }
+
+  /* Saved-credentials acknowledgement checkbox (second way to clear the
+   * beforeunload guard, for operators who copy-paste instead of
+   * downloading). */
+  .saved-ack { margin-top: 16px; font-size: 0.9rem; color: #333; }
+  .saved-ack input[type=checkbox] { margin-right: 6px; vertical-align: middle; }
 """
 
 
@@ -232,6 +324,7 @@ def _render_setup_form(
 <style>{_BASE_STYLE}</style>
 </head>
 <body>
+  {_render_brand_header()}
   <h1>Welcome to Brilliant</h1>
   <p class="sub">Let's finish setting up your knowledge base.</p>
   <div class="info">
@@ -311,6 +404,23 @@ def _render_done_page(
     ``meta http-equiv="refresh"`` is ever injected, since an auto-refresh
     would obscure the plaintext API key that is only rendered in this
     response. See spec 0042 / T-0251.
+
+    Polish applied in spec 0043 / T-0255:
+
+    - Brand header (logo + title SVG + tagline) matches the README brand
+      mark, inlined to keep the page dependency-free.
+    - Download button carries a ``pulse`` class with a CSS keyframe
+      animation so the CTA is unmissable; JS clears the class on first
+      click and writes ``localStorage.brilliant_creds_downloaded = "1"``.
+    - ``beforeunload`` listener triggers the browser's "leave site?"
+      prompt until the operator clicks download OR checks the "I've saved
+      my credentials" checkbox. Both paths call ``clearGuard()``.
+    - Secondary Import Obsidian vault button carries the plaintext
+      ``api_key`` as a URL fragment (``#api_key=…``) — fragments stay on
+      the client, so ``/import/vault`` can autofill the vault-upload
+      page's localStorage + input without the key ever hitting the
+      server. The destination page clears the fragment via
+      ``history.replaceState`` on load.
     """
     safe_email = _html.escape(email, quote=True)
     safe_key = _html.escape(api_key, quote=True)
@@ -318,6 +428,14 @@ def _render_done_page(
     safe_client_secret = _html.escape(client_secret, quote=True)
     safe_mcp = _html.escape(mcp_url, quote=True)
     safe_login = _html.escape(login_url, quote=True)
+
+    # Fragment-carrying Import Vault link: the api_key rides in the URL
+    # fragment so it never hits the server (fragments are client-side
+    # only). /import/vault reads window.location.hash, stuffs the key
+    # into localStorage, then replaces history state to strip the
+    # fragment from the visible URL so a copy-paste / back-nav doesn't
+    # expose the secret.
+    safe_import_vault_href = f"/import/vault#api_key={_html.escape(api_key, quote=True)}"
 
     # JSON-encode for safe JS embedding — sidesteps any quoting surprises
     # inside the Blob contents.
@@ -330,6 +448,8 @@ def _render_done_page(
 
     warming_banner = "" if services_ready else _WARMING_BANNER
 
+    brand_header = _render_brand_header()
+
     return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -339,6 +459,7 @@ def _render_done_page(
 <style>{_BASE_STYLE}</style>
 </head>
 <body>
+  {brand_header}
   <h1>You're live</h1>
   <p class="sub">Your admin account is created. Save these credentials now.</p>
 
@@ -393,15 +514,16 @@ def _render_done_page(
   </div>
 
   <div class="actions">
-    <button type="button" id="download">Download brilliant-credentials.txt</button>
+    <button type="button" id="download" class="pulse">Download brilliant-credentials.txt</button>
+    <a id="import-vault-btn" class="button secondary"
+       href="{safe_import_vault_href}" target="_blank" rel="noopener">Import Obsidian vault</a>
   </div>
 
-  <div class="field">
-    <div class="field-label">Optional next step</div>
-    <div class="info">
-      Already have an Obsidian vault? <a href="/import/vault">Import it now</a>
-      to seed your knowledge base.
-    </div>
+  <div class="saved-ack">
+    <label>
+      <input type="checkbox" id="saved-ack-checkbox">
+      I've saved my credentials
+    </label>
   </div>
 
 <script>
@@ -411,6 +533,37 @@ def _render_done_page(
   const CLIENT_SECRET = {js_client_secret};
   const MCP_URL = {js_mcp};
   const LOGIN_URL = {js_login};
+
+  // ----- beforeunload guard -----
+  // Browser confirms navigation away as long as `guardActive` is true. It
+  // flips to false on either (a) a download-click, or (b) an explicit
+  // check of the "I've saved my credentials" checkbox. Either action
+  // also writes `brilliant_creds_downloaded=1` so a future page refresh
+  // doesn't re-arm the guard. The API key is rendered on this exact
+  // response body; a refresh re-GETs /setup/done which 404s post-claim —
+  // which is why the guard is worth the UX friction.
+  let guardActive = true;
+
+  function clearGuard() {{
+    guardActive = false;
+    const btn = document.getElementById("download");
+    if (btn) {{
+      btn.classList.remove("pulse");
+    }}
+    try {{
+      window.localStorage.setItem("brilliant_creds_downloaded", "1");
+    }} catch (e) {{ /* localStorage disabled — ignore */ }}
+  }}
+
+  window.addEventListener("beforeunload", (ev) => {{
+    if (!guardActive) return;
+    ev.preventDefault();
+    // Most modern browsers ignore the returnValue string and show their
+    // own generic "Leave site?" dialog — but setting it is the spec'd
+    // way to trigger the prompt. Keep the message short.
+    ev.returnValue = "You haven't saved your credentials yet.";
+    return ev.returnValue;
+  }});
 
   async function copyText(text, btn) {{
     try {{
@@ -456,6 +609,17 @@ def _render_done_page(
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
+    // Stop pulsing + disarm the beforeunload guard on first click. We
+    // intentionally clear the guard on download-start (not download-
+    // finish) because the browser fires the click event synchronously
+    // before the Blob save dialog resolves.
+    clearGuard();
+  }});
+
+  document.getElementById("saved-ack-checkbox").addEventListener("change", (ev) => {{
+    if (ev.currentTarget.checked) {{
+      clearGuard();
+    }}
   }});
 </script>
 </body>
@@ -612,3 +776,307 @@ async def setup_done() -> HTMLResponse:
     pool = get_pool()
     await _require_first_run_open(pool)
     return HTMLResponse(_render_done_nudge())
+
+
+# ---------------------------------------------------------------------------
+# /credentials — Sprint 0043 T-0254 (Issue #45 Option B)
+# ---------------------------------------------------------------------------
+#
+# Recovery route. Operators who lose ``brilliant-credentials.txt`` can
+# re-fetch the six-field payload with their admin API key. The payload
+# shape matches the installer file byte-for-byte so a user can
+# ``curl ... > brilliant-credentials.txt`` the response and have a
+# drop-in replacement.
+#
+# Auth: reuses :func:`auth.get_current_user` (Bearer token in
+# ``Authorization: Bearer <api_key>``). Admin-role gated — non-admin
+# callers get 403. No Bearer → 401 (enforced by
+# :func:`auth._extract_bearer_token`).
+#
+# Fields sourced:
+#   * admin_email         — ``users.email`` for the authenticated admin.
+#   * admin_api_key       — the Bearer token the caller presented (we
+#                            verified it already; the DB stores only the
+#                            bcrypt hash, so there is no other way to
+#                            echo it back).
+#   * oauth_client_id     — first row of ``oauth_clients`` (there is
+#                            exactly one, minted by admin_bootstrap).
+#   * oauth_client_secret — matching row's plaintext secret.
+#   * mcp_url             — :func:`_mcp_url_for_display` (DB +
+#                            ``BRILLIANT_MCP_PUBLIC_URL`` env fallback).
+#   * login_url           — DB ``api_public_url`` →
+#                            ``API_BASE_URL`` env →
+#                            request host, each suffixed with
+#                            ``/auth/login``.
+#
+# Content negotiation: default JSON; HTML if ``Accept: text/html`` is
+# the top-ranked preference. HTML body is a minimal ``<pre>`` + copy
+# button (no brand chrome needed — this is an ops recovery surface,
+# not the one-shot ceremony).
+
+
+def _require_admin(user: UserContext) -> None:
+    """Raise 403 if the caller is not an admin.
+
+    Mirrors the private helper used across other admin-gated routes
+    (``api/routes/users.py``, ``api/routes/analytics.py``, etc.). Kept
+    module-local to avoid a cross-module import for a two-line check.
+    """
+    if user.role != "admin":
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+
+async def _fetch_oauth_client_creds(pool) -> tuple[str, str]:
+    """Return ``(client_id, client_secret)`` for the installed OAuth client.
+
+    There is exactly one pre-registered row minted by
+    :func:`admin_bootstrap._create_admin_and_flip_latch`. If multiple
+    rows exist (manual DB edits, re-registered client), we return the
+    most recently created one — which matches what Claude Co-work would
+    be configured against.
+
+    Raises HTTPException(500) if the table is empty (bootstrap
+    incomplete — should be impossible behind admin auth, but fail-loud
+    beats returning an opaque null).
+    """
+    async with pool.connection() as conn:
+        cur = await conn.execute(
+            """
+            SELECT client_id, client_secret
+            FROM oauth_clients
+            ORDER BY created_at DESC
+            LIMIT 1
+            """
+        )
+        row = await cur.fetchone()
+
+    if row is None:
+        raise HTTPException(
+            status_code=500,
+            detail="OAuth client not found; admin_bootstrap incomplete",
+        )
+    return str(row[0]), str(row[1])
+
+
+async def _fetch_admin_email(pool, user_id: str) -> str:
+    """Return the authenticated admin's email.
+
+    The :class:`UserContext` returned by :func:`auth.get_current_user`
+    doesn't carry ``email`` (it never needed to — auth only needs
+    role + org + id). We fetch it here via a single SELECT so the
+    recovery payload can echo it as ``admin_email=...``.
+
+    Returns an empty string when the email is NULL (legacy API-key-only
+    admins from pre-013_user_auth.sql deploys). The six-field contract
+    still requires the key to be present, so the caller just emits an
+    empty value rather than a null.
+    """
+    async with pool.connection() as conn:
+        cur = await conn.execute(
+            "SELECT email FROM users WHERE id = %s",
+            (user_id,),
+        )
+        row = await cur.fetchone()
+
+    if row is None or row[0] is None:
+        return ""
+    return str(row[0])
+
+
+async def _login_url_for_credentials(request: Request, pool) -> str:
+    """Render the ``/auth/login`` URL with the same resolution order
+    used at install time.
+
+    Priority:
+
+    1. ``brilliant_settings.api_public_url`` (migration 032) — set by
+       the API service on boot from ``RENDER_EXTERNAL_URL``. Authoritative
+       on Render deploys; NULL on a fresh local dev DB.
+    2. ``API_BASE_URL`` env var — local dev override /
+       docker-compose plumbing.
+    3. The inbound request's scheme + host — last-resort for local
+       curls where neither of the above is set.
+    """
+    base: str | None = None
+    try:
+        async with pool.connection() as conn:
+            cur = await conn.execute(
+                "SELECT api_public_url FROM brilliant_settings WHERE id = 1"
+            )
+            row = await cur.fetchone()
+        if row and row[0]:
+            base = str(row[0])
+    except Exception:
+        # Column may not exist yet (migration 032 pending); fall through.
+        base = None
+
+    if not base:
+        raw = os.getenv("API_BASE_URL", "").strip()
+        if raw:
+            if raw.startswith("http://") or raw.startswith("https://"):
+                base = raw
+            else:
+                base = f"https://{raw}"
+
+    if not base:
+        scheme = request.url.scheme
+        host = request.headers.get("host") or request.url.netloc
+        base = f"{scheme}://{host}"
+
+    return f"{base.rstrip('/')}/auth/login"
+
+
+def _render_credentials_html(payload: dict) -> str:
+    """Render the minimal HTML view of the six-field payload.
+
+    One-way ops surface: a ``<pre>`` block with the exact
+    ``key=value`` lines the installer wrote to
+    ``brilliant-credentials.txt``, plus a single copy-to-clipboard
+    button. Intentionally unstyled brand chrome — this page is for
+    operators recovering a lost file, not the one-shot ceremony.
+    """
+    lines = "\n".join(f"{k}={payload[k]}" for k in _CREDENTIAL_FIELD_ORDER)
+    safe_lines = _html.escape(lines)
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Brilliant credentials</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+         max-width: 680px; margin: 48px auto; padding: 0 16px; color: #111;
+         line-height: 1.5; }}
+  h1 {{ font-size: 1.4rem; margin-bottom: 0.25rem; }}
+  p.sub {{ color: #555; margin-top: 0; }}
+  pre {{ background: #f4f4f4; border: 1px solid #ddd; border-radius: 6px;
+         padding: 16px; overflow-x: auto; font-size: 0.95rem;
+         white-space: pre-wrap; word-break: break-all; }}
+  button {{ padding: 10px 14px; font-size: 1rem; background: #2f5ad8;
+           color: #fff; border: 0; border-radius: 6px; cursor: pointer;
+           margin-top: 12px; }}
+  button:hover {{ background: #1f48c2; }}
+  .note {{ color: #555; font-size: 0.85rem; margin-top: 16px; }}
+</style>
+</head>
+<body>
+  <h1>Brilliant credentials</h1>
+  <p class="sub">Save this file as <code>brilliant-credentials.txt</code>.</p>
+  <pre id="creds">{safe_lines}</pre>
+  <button type="button" id="copy-btn">Copy all</button>
+  <p class="note">
+    This page only shows the admin API key you authenticated with.
+    Rotate it via <code>/auth/login</code> if you suspect it's compromised.
+  </p>
+<script>
+  document.getElementById("copy-btn").addEventListener("click", async (ev) => {{
+    const text = document.getElementById("creds").textContent;
+    try {{
+      await navigator.clipboard.writeText(text);
+      const btn = ev.currentTarget;
+      const prev = btn.textContent;
+      btn.textContent = "Copied";
+      setTimeout(() => {{ btn.textContent = prev; }}, 1500);
+    }} catch (e) {{
+      alert("Copy failed — select the text manually.");
+    }}
+  }});
+</script>
+</body>
+</html>
+"""
+
+
+# Canonical field order for the six-field credential contract. Matches
+# :func:`admin_bootstrap.ensure_admin_user`'s machine-parseable block
+# and install.sh's ``brilliant-credentials.txt`` writer. Any change here
+# must also update T-0253's installer code in lockstep.
+_CREDENTIAL_FIELD_ORDER = (
+    "admin_email",
+    "admin_api_key",
+    "oauth_client_id",
+    "oauth_client_secret",
+    "mcp_url",
+    "login_url",
+)
+
+
+def _prefers_html(request: Request) -> bool:
+    """Return True when the client's ``Accept`` header tops HTML.
+
+    We intentionally keep this simple — a strict RFC 7231 quality-value
+    parser would be overkill for a recovery surface. If ``text/html``
+    appears anywhere in ``Accept`` AND ``application/json`` does not, we
+    render HTML; otherwise JSON (the default for ``curl`` and scripted
+    callers that omit ``Accept`` entirely).
+    """
+    accept = (request.headers.get("accept") or "").lower()
+    if not accept or accept == "*/*":
+        return False
+    if "application/json" in accept:
+        return False
+    return "text/html" in accept
+
+
+@router.get("/credentials")
+async def credentials_recovery(
+    request: Request,
+    user: UserContext = Depends(get_current_user),
+):
+    """Admin-gated recovery surface for the six-field credential payload.
+
+    Re-emits the exact same ``key=value`` fields that the installer
+    wrote to ``brilliant-credentials.txt``, so an operator who lost
+    that file can restore it with:
+
+    .. code-block:: sh
+
+        curl -H "Authorization: Bearer $ADMIN_KEY" \\
+             http://localhost:8010/credentials \\
+             > brilliant-credentials.txt
+
+    Auth: :func:`auth.get_current_user` verifies the Bearer token
+    (401 on missing / invalid). :func:`_require_admin` enforces
+    ``role=admin`` (403 for non-admin users).
+
+    Content negotiation: default JSON; HTML ``<pre>`` block when the
+    client's ``Accept`` header requests ``text/html`` explicitly.
+
+    admin_api_key note: the DB stores only the bcrypt hash of the key.
+    We echo the plaintext Bearer the caller already presented, because
+    the auth middleware has bcrypt-verified it against the stored hash.
+    That means this route is safe to call from a machine that has the
+    key but lost the creds file; it is NOT a key-recovery surface for
+    operators who've lost the key entirely (those must rotate via
+    ``/auth/login``).
+    """
+    _require_admin(user)
+
+    pool = get_pool()
+
+    # Extract the Bearer token to echo back as admin_api_key — this is
+    # the only way to put the plaintext on the wire, since the DB only
+    # has the bcrypt hash. Auth already verified it against the hash,
+    # so it's safe to round-trip.
+    auth_header = request.headers.get("Authorization") or ""
+    parts = auth_header.split(" ", 1)
+    admin_api_key = parts[1].strip() if len(parts) == 2 else ""
+
+    admin_email = await _fetch_admin_email(pool, user.id)
+    client_id, client_secret = await _fetch_oauth_client_creds(pool)
+    mcp_url = await _mcp_url_for_display(pool)
+    login_url = await _login_url_for_credentials(request, pool)
+
+    payload = {
+        "admin_email": admin_email,
+        "admin_api_key": admin_api_key,
+        "oauth_client_id": client_id,
+        "oauth_client_secret": client_secret,
+        "mcp_url": mcp_url,
+        "login_url": login_url,
+    }
+
+    if _prefers_html(request):
+        return HTMLResponse(_render_credentials_html(payload))
+
+    return JSONResponse(payload)

--- a/db/migrations/.gitignore
+++ b/db/migrations/.gitignore
@@ -1,0 +1,20 @@
+# Only numbered schema migrations belong in this directory. They are
+# bind-mounted read-only into the Postgres container at
+# /docker-entrypoint-initdb.d and run automatically on first-boot of
+# an empty pgdata volume.
+#
+# Stray demo/seed SQL files (e.g. a copied db/seed/demo.sql, or a
+# revived 005_seed.sql) would be auto-applied by Postgres's init-scripts
+# hook and re-seed a clean install — so we refuse to commit them.
+# Demo data is opt-in via `install.sh --seed-demo`, which applies
+# db/seed/demo.sql through `docker exec` post-init — never through
+# this mount.
+#
+# Block demo/seed artifacts by filename pattern. Legitimate migration
+# 020_strip_frontmatter_seed.sql is pre-committed and unaffected by
+# these rules (gitignore only prevents NEW additions; tracked files stay).
+demo.sql
+demo*.sql
+**/demo.sql
+seed.sql
+999_demo_seed.sql

--- a/db/seed/demo.sql
+++ b/db/seed/demo.sql
@@ -1,5 +1,20 @@
--- 005_seed.sql
--- Seed data for demo: 1 org, 4 users, 5 API keys, 12 entries, links, versions, staging, audit.
+-- demo.sql
+-- Opt-in demo seed data: 1 org (shared with admin bootstrap), 4 demo users,
+-- 5 API keys, 12 entries, links, versions, staging, audit.
+--
+-- This file is NOT in db/migrations/ and does NOT auto-run on a clean
+-- install. Opt in via `install.sh --seed-demo` (which applies this script
+-- via `docker exec -i brilliant-db psql … < db/seed/demo.sql` after the
+-- stack is healthy). Remove at any time with:
+--
+--   python tools/remove_demo_data.py --yes
+--
+-- Every entry row carries the `demo:seed` tag so the removal script can
+-- identify and delete demo-only rows without touching real content.
+-- Non-entry rows (api_keys, users, staging, audit_log, project_assignments)
+-- are identified by their stable demo IDs (`usr_admin`, `usr_editor`,
+-- `usr_commenter`, `usr_viewer`) — real admin-bootstrap users have UUID
+-- ids, so the two populations do not collide.
 --
 -- Plaintext API keys (for demo scripts):
 --   Admin:     bkai_adm1_testkey_admin
@@ -8,16 +23,26 @@
 --   Viewer:    bkai_view_testkey_viewer
 --   Agent:     bkai_agnt_testkey_agent
 --
--- Depends on: 001_core.sql, 002_relationships.sql, 003_governance.sql, 004_rls.sql
+-- Idempotent-ish: inserts use explicit IDs, so re-running will raise a
+-- unique-constraint error. Run `tools/remove_demo_data.py --yes` first
+-- if you need to re-seed.
+--
+-- Depends on: 001_core.sql, 002_relationships.sql, 003_governance.sql,
+--             004_rls.sql, and the admin-bootstrap'd organizations row.
 
 BEGIN;
 
 -- =============================================================================
 -- ORGANIZATION
 -- =============================================================================
+-- On a fresh install the admin-bootstrap flow creates org_demo with the
+-- operator-chosen name. If it hasn't run yet (pure --seed-demo with no
+-- /setup call first), insert a baseline row. ON CONFLICT DO NOTHING so we
+-- don't clobber an operator-chosen name.
 
 INSERT INTO organizations (id, name, settings) VALUES
-    ('org_demo', 'Demo Organization', '{"governance_tier_default": 2, "max_entries": 10000}');
+    ('org_demo', 'Demo Organization', '{"governance_tier_default": 2, "max_entries": 10000}')
+ON CONFLICT (id) DO NOTHING;
 
 -- =============================================================================
 -- USERS (one per role)
@@ -28,6 +53,13 @@ INSERT INTO users (id, org_id, display_name, email_hash, role, department, trust
     ('usr_editor',    'org_demo', 'Eddie Editor',    encode(digest('eddie@demo.org', 'sha256'), 'hex'), 'editor',    'engineering', 0.75),
     ('usr_commenter', 'org_demo', 'Carol Commenter', encode(digest('carol@demo.org', 'sha256'), 'hex'), 'commenter', 'sales',       0.60),
     ('usr_viewer',    'org_demo', 'Victor Viewer',   encode(digest('victor@demo.org', 'sha256'), 'hex'), 'viewer',    NULL,          0.50);
+
+-- Migration 013_user_auth.sql back-fills emails when id matches + email IS NULL.
+-- Run that logic inline here so --seed-demo works regardless of migration order.
+UPDATE users SET email = 'alice@demo.org'  WHERE id = 'usr_admin'     AND email IS NULL;
+UPDATE users SET email = 'eddie@demo.org'  WHERE id = 'usr_editor'    AND email IS NULL;
+UPDATE users SET email = 'carol@demo.org'  WHERE id = 'usr_commenter' AND email IS NULL;
+UPDATE users SET email = 'victor@demo.org' WHERE id = 'usr_viewer'    AND email IS NULL;
 
 -- =============================================================================
 -- API KEYS (4 interactive + 1 agent)
@@ -42,10 +74,9 @@ INSERT INTO api_keys (user_id, org_id, key_hash, key_prefix, key_type, label) VA
 
 -- =============================================================================
 -- ENTRIES (12 entries, various types/sensitivities/departments)
+-- Every entry carries the `demo:seed` tag for one-shot cleanup via
+-- tools/remove_demo_data.py --yes.
 -- =============================================================================
-
--- We use gen_random_uuid() inline; reference them via variables for linking.
--- To enable cross-referencing, we insert with explicit UUIDs.
 
 INSERT INTO entries (id, org_id, title, content, summary, content_hash, content_type, logical_path, sensitivity, department, owner_id, tags, source, created_by, updated_by, status) VALUES
 
@@ -56,7 +87,7 @@ INSERT INTO entries (id, org_id, title, content, summary, content_hash, content_
  'Core mission statement for the organization.',
  md5('Our mission is to democratize institutional knowledge through AI-powered systems that ensure every team member has access to the context they need.'),
  'context', 'Context/mission', 'shared', NULL, 'usr_admin',
- ARRAY['mission', 'core'], 'web_ui', 'usr_admin', 'usr_admin', 'published'),
+ ARRAY['mission', 'core', 'demo:seed'], 'web_ui', 'usr_admin', 'usr_admin', 'published'),
 
 -- 2. Engineering project entry
 ('a0000000-0000-0000-0000-000000000002', 'org_demo',
@@ -65,7 +96,7 @@ INSERT INTO entries (id, org_id, title, content, summary, content_hash, content_
  'API redesign project targeting Q3 launch.',
  md5('Project Alpha aims to redesign the core API layer for better performance and scalability. Target: Q3 launch with 10x throughput improvement.'),
  'project', 'Projects/alpha', 'project', 'engineering', 'usr_editor',
- ARRAY['api', 'performance', 'q3'], 'web_ui', 'usr_editor', 'usr_editor', 'published'),
+ ARRAY['api', 'performance', 'q3', 'demo:seed'], 'web_ui', 'usr_editor', 'usr_editor', 'published'),
 
 -- 3. Meeting notes
 ('a0000000-0000-0000-0000-000000000003', 'org_demo',
@@ -74,7 +105,7 @@ INSERT INTO entries (id, org_id, title, content, summary, content_hash, content_
  'Weekly standup covering API progress and sales pipeline.',
  md5('Attendees: Alice, Eddie, Carol. Topics: API progress at 60%, sales pipeline review, hiring update. Action items: Eddie to finalize schema by Friday.'),
  'meeting', 'Meetings/standup/2026-04-01', 'meeting', NULL, 'usr_admin',
- ARRAY['standup', 'weekly'], 'web_ui', 'usr_admin', 'usr_admin', 'published'),
+ ARRAY['standup', 'weekly', 'demo:seed'], 'web_ui', 'usr_admin', 'usr_admin', 'published'),
 
 -- 4. Strategic decision (admin/leadership only)
 ('a0000000-0000-0000-0000-000000000004', 'org_demo',
@@ -83,7 +114,7 @@ INSERT INTO entries (id, org_id, title, content, summary, content_hash, content_
  'Decided on row-level multi-tenancy over per-client instances.',
  md5('After evaluating options, we decided on row-level multi-tenancy with org_id + RLS over per-client instances. Rationale: lower ops cost, simpler deployment, good enough isolation for our threat model.'),
  'decision', 'Decisions/architecture/multi-tenant', 'strategic', 'leadership', 'usr_admin',
- ARRAY['architecture', 'multi-tenant', 'rls'], 'web_ui', 'usr_admin', 'usr_admin', 'published'),
+ ARRAY['architecture', 'multi-tenant', 'rls', 'demo:seed'], 'web_ui', 'usr_admin', 'usr_admin', 'published'),
 
 -- 5. Sales intelligence (operational, sales dept)
 ('a0000000-0000-0000-0000-000000000005', 'org_demo',
@@ -92,7 +123,7 @@ INSERT INTO entries (id, org_id, title, content, summary, content_hash, content_
  'Competitive pricing intel on Acme Corp.',
  md5('Acme Corp has moved to usage-based pricing at $0.10/query. Their enterprise tier starts at $2K/mo. Key differentiator: they lack multi-agent support.'),
  'intelligence', 'Intelligence/competitive/acme', 'operational', 'sales', 'usr_commenter',
- ARRAY['competitive', 'pricing', 'acme'], 'agent', 'usr_commenter', 'usr_commenter', 'published'),
+ ARRAY['competitive', 'pricing', 'acme', 'demo:seed'], 'agent', 'usr_commenter', 'usr_commenter', 'published'),
 
 -- 6. Private note (only owner sees)
 ('a0000000-0000-0000-0000-000000000006', 'org_demo',
@@ -101,7 +132,7 @@ INSERT INTO entries (id, org_id, title, content, summary, content_hash, content_
  'Personal notes on CRDT research.',
  md5('Looking into CRDT-based sync as alternative to Git for real-time collaboration. Papers to read: Automerge, Yjs internals.'),
  'resource', 'Resources/research/crdt-notes', 'private', 'engineering', 'usr_editor',
- ARRAY['crdt', 'research', 'sync'], 'web_ui', 'usr_editor', 'usr_editor', 'draft'),
+ ARRAY['crdt', 'research', 'sync', 'demo:seed'], 'web_ui', 'usr_editor', 'usr_editor', 'draft'),
 
 -- 7. System entry (only admin sees)
 ('a0000000-0000-0000-0000-000000000007', 'org_demo',
@@ -110,7 +141,7 @@ INSERT INTO entries (id, org_id, title, content, summary, content_hash, content_
  'System documentation for RLS policies.',
  md5('Row-level security policies are defined in 004_rls.sql. Admin sees all, viewer excludes private/system, agent writes go to staging.'),
  'system', 'System/rls-policies', 'system', NULL, 'usr_admin',
- ARRAY['system', 'rls', 'security'], 'web_ui', 'usr_admin', 'usr_admin', 'published'),
+ ARRAY['system', 'rls', 'security', 'demo:seed'], 'web_ui', 'usr_admin', 'usr_admin', 'published'),
 
 -- 8. Onboarding guide (shared)
 ('a0000000-0000-0000-0000-000000000008', 'org_demo',
@@ -119,7 +150,7 @@ INSERT INTO entries (id, org_id, title, content, summary, content_hash, content_
  'Step-by-step onboarding for new employees.',
  md5('Welcome! Start by reading the mission statement, then review your department folder. Set up your API key through the GUI. Contact your manager for project assignments.'),
  'onboarding', 'Onboarding/new-employee', 'shared', NULL, 'usr_admin',
- ARRAY['onboarding', 'getting-started'], 'web_ui', 'usr_admin', 'usr_admin', 'published'),
+ ARRAY['onboarding', 'getting-started', 'demo:seed'], 'web_ui', 'usr_admin', 'usr_admin', 'published'),
 
 -- 9. Engineering resource (operational)
 ('a0000000-0000-0000-0000-000000000009', 'org_demo',
@@ -128,7 +159,7 @@ INSERT INTO entries (id, org_id, title, content, summary, content_hash, content_
  'API authentication specification and rate limits.',
  md5('All API requests require Bearer token in Authorization header. Tokens are validated by prefix lookup + bcrypt verify. Rate limits: 100 req/min interactive, 500 req/min agent.'),
  'resource', 'Resources/engineering/auth-spec', 'operational', 'engineering', 'usr_editor',
- ARRAY['api', 'auth', 'spec'], 'web_ui', 'usr_editor', 'usr_editor', 'published'),
+ ARRAY['api', 'auth', 'spec', 'demo:seed'], 'web_ui', 'usr_editor', 'usr_editor', 'published'),
 
 -- 10. Agent-created intelligence entry
 ('a0000000-0000-0000-0000-00000000000a', 'org_demo',
@@ -137,7 +168,7 @@ INSERT INTO entries (id, org_id, title, content, summary, content_hash, content_
  'Market landscape analysis of KB tools.',
  md5('Analysis of 15 knowledge base tools shows convergence on AI-augmented search. Key trends: vector embeddings standard, graph relationships emerging, multi-agent collaboration rare.'),
  'intelligence', 'Intelligence/market/kb-tools', 'shared', NULL, 'usr_editor',
- ARRAY['market-research', 'kb', 'ai'], 'agent', 'usr_editor', 'usr_editor', 'published'),
+ ARRAY['market-research', 'kb', 'ai', 'demo:seed'], 'agent', 'usr_editor', 'usr_editor', 'published'),
 
 -- 11. Sales department daily context
 ('a0000000-0000-0000-0000-00000000000b', 'org_demo',
@@ -146,7 +177,7 @@ INSERT INTO entries (id, org_id, title, content, summary, content_hash, content_
  'Daily sales pipeline update.',
  md5('Pipeline: 3 new leads, 2 demos scheduled. Follow-up needed: TechCorp (sent proposal), DataSoft (awaiting budget approval). Revenue forecast on track.'),
  'daily', 'Daily/sales/2026-04-03', 'operational', 'sales', 'usr_commenter',
- ARRAY['sales', 'daily', 'pipeline'], 'web_ui', 'usr_commenter', 'usr_commenter', 'published'),
+ ARRAY['sales', 'daily', 'pipeline', 'demo:seed'], 'web_ui', 'usr_commenter', 'usr_commenter', 'published'),
 
 -- 12. Leadership strategic entry
 ('a0000000-0000-0000-0000-00000000000c', 'org_demo',
@@ -155,7 +186,7 @@ INSERT INTO entries (id, org_id, title, content, summary, content_hash, content_
  'Q3 strategic priorities and budget.',
  md5('Three priorities for Q3: (1) Launch multi-tenant platform, (2) Close 5 enterprise deals, (3) Hire 3 engineers. Budget allocated: $150K for infrastructure.'),
  'context', 'Context/strategy/q3-priorities', 'strategic', 'leadership', 'usr_admin',
- ARRAY['strategy', 'q3', 'priorities'], 'web_ui', 'usr_admin', 'usr_admin', 'published');
+ ARRAY['strategy', 'q3', 'priorities', 'demo:seed'], 'web_ui', 'usr_admin', 'usr_admin', 'published');
 
 -- =============================================================================
 -- ENTRY LINKS (6 links connecting entries)
@@ -185,14 +216,14 @@ INSERT INTO entry_versions (entry_id, org_id, version, title, content, content_h
      'Company Mission Statement',
      'Our mission is to build the best knowledge base platform.',
      md5('Our mission is to build the best knowledge base platform.'),
-     ARRAY['mission'], 'published', 'usr_admin', 'web_ui',
+     ARRAY['mission', 'demo:seed'], 'published', 'usr_admin', 'web_ui',
      'Initial creation of mission statement', 'created'),
     -- Version 1 of API auth spec (before update to v2)
     ('a0000000-0000-0000-0000-000000000009', 'org_demo', 1,
      'API Authentication Spec',
      'API requests require Bearer token. Tokens validated by bcrypt. No rate limits yet.',
      md5('API requests require Bearer token. Tokens validated by bcrypt. No rate limits yet.'),
-     ARRAY['api', 'auth'], 'published', 'usr_editor', 'web_ui',
+     ARRAY['api', 'auth', 'demo:seed'], 'published', 'usr_editor', 'web_ui',
      'Initial auth spec before rate limits added', 'created');
 
 -- =============================================================================
@@ -205,7 +236,7 @@ INSERT INTO staging (org_id, target_entry_id, target_path, change_type, proposed
      'Intelligence/market/kb-tools', 'update',
      'Market Research: KB Tools Landscape (Updated)',
      'Updated analysis of 20 knowledge base tools. New entrant: CortexDB with graph-native approach. Vector search now table stakes.',
-     '{"update_reason": "quarterly refresh"}',
+     '{"update_reason": "quarterly refresh", "demo_seed": true}',
      md5('Updated analysis of 20 knowledge base tools. New entrant: CortexDB with graph-native approach. Vector search now table stakes.'),
      'usr_editor', 'agent', 2, 'teaching_loop', 'pending', 2),
     -- Approved: commenter proposed new sales playbook
@@ -213,7 +244,7 @@ INSERT INTO staging (org_id, target_entry_id, target_path, change_type, proposed
      'Resources/sales/playbook-enterprise', 'create',
      'Enterprise Sales Playbook',
      'Step 1: Identify decision maker. Step 2: Schedule discovery call. Step 3: Present ROI analysis. Step 4: Pilot proposal.',
-     '{"category": "sales_enablement"}',
+     '{"category": "sales_enablement", "demo_seed": true}',
      md5('Step 1: Identify decision maker. Step 2: Schedule discovery call. Step 3: Present ROI analysis. Step 4: Pilot proposal.'),
      'usr_commenter', 'web_ui', 1, 'user_direct', 'approved', 3);
 

--- a/db/seed/demo.sql
+++ b/db/seed/demo.sql
@@ -4,7 +4,7 @@
 --
 -- This file is NOT in db/migrations/ and does NOT auto-run on a clean
 -- install. Opt in via `install.sh --seed-demo` (which applies this script
--- via `docker exec -i brilliant-db psql … < db/seed/demo.sql` after the
+-- via `docker compose exec -T db psql … < db/seed/demo.sql` after the
 -- stack is healthy). Remove at any time with:
 --
 --   python tools/remove_demo_data.py --yes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,12 @@
 services:
   db:
     image: pgvector/pgvector:pg16
-    container_name: brilliant-db
+    # No `container_name:` — Sprint 0043 T-0259. Hardcoded names collided
+    # across sibling installs (compose's default project name is the parent
+    # dir basename, which normalizes to `xireactor-brilliant` for every
+    # self-clone target). Compose auto-names containers as
+    # `${COMPOSE_PROJECT_NAME}-db-1` instead; install.sh mints a pwd-hashed
+    # project name into `.env` so two checkouts can coexist.
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-dev}
@@ -31,7 +36,7 @@ services:
     build:
       context: .
       dockerfile: ./api/Dockerfile
-    container_name: brilliant-api
+    # No `container_name:` — see db service comment (T-0259).
     depends_on:
       db:
         condition: service_healthy
@@ -57,7 +62,7 @@ services:
 
   mcp:
     build: ./mcp
-    container_name: brilliant-mcp
+    # No `container_name:` — see db service comment (T-0259).
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,11 @@ services:
       # Fall back to canonical defaults when install.sh did not run.
       MCP_BASE_URL: ${MCP_BASE_URL:-http://localhost:8011}
       API_BASE_URL: ${API_BASE_URL:-http://localhost:8010}
+      # Shared HMAC secret for /oauth/login → /oauth/continue handoff. Must
+      # match the MCP service's value. install.sh mints one into .env on
+      # fresh installs (Sprint 0044 follow-up); Render generates+shares via
+      # render.yaml fromService.envVarKey.
+      OAUTH_HANDOFF_SECRET: ${OAUTH_HANDOFF_SECRET:-}
     restart: unless-stopped
 
   mcp:
@@ -80,6 +85,7 @@ services:
       MCP_BASE_URL: ${MCP_BASE_URL:-http://localhost:8011}
       MCP_PORT: "8001"
       DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-dev}@db:5432/${POSTGRES_DB:-brilliant}
+      OAUTH_HANDOFF_SECRET: ${OAUTH_HANDOFF_SECRET:-}
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,20 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-dev}
       POSTGRES_DB: ${POSTGRES_DB:-brilliant}
     ports:
-      - "5442:5432"
+      # Host port is probed by install.sh (Sprint 0043 T-0257); falls back
+      # to 5442 when install.sh is not the entrypoint or no conflict was
+      # found. Container port is always 5432.
+      - "${BRILLIANT_DB_PORT:-5442}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
-      - ./db/migrations:/docker-entrypoint-initdb.d
+      # Init-scripts bind: read-only, migrations-only. A `.gitignore` guard in
+      # db/migrations/ blocks stray .sql files (e.g. an old 005_seed.sql
+      # revival) from being committed back into this mount, so the only
+      # Postgres auto-bootstrap inputs are the numbered schema migrations.
+      # Demo seed (opt-in via `install.sh --seed-demo`) is applied AFTER the
+      # stack is healthy via `docker exec -i brilliant-db psql … < db/seed/demo.sql`,
+      # never through this mount — see install.sh phase_seed.
+      - ./db/migrations:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d brilliant"]
       interval: 5s
@@ -26,7 +36,9 @@ services:
       db:
         condition: service_healthy
     ports:
-      - "8010:8000"
+      # Parameterized for port-probe (Sprint 0043 T-0257). Container port
+      # is always 8000.
+      - "${BRILLIANT_API_PORT:-8010}:8000"
     volumes:
       - ./api:/app
     environment:
@@ -35,6 +47,12 @@ services:
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-}
       ADMIN_API_KEY: ${ADMIN_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      # Sprint 0043 T-0257 — admin_bootstrap reads these when emitting
+      # the credential block so brilliant-credentials.txt carries the
+      # operator-visible URLs that match the host-side port bindings.
+      # Fall back to canonical defaults when install.sh did not run.
+      MCP_BASE_URL: ${MCP_BASE_URL:-http://localhost:8011}
+      API_BASE_URL: ${API_BASE_URL:-http://localhost:8010}
     restart: unless-stopped
 
   mcp:
@@ -46,7 +64,9 @@ services:
       api:
         condition: service_started
     ports:
-      - "8011:8001"
+      # Parameterized for port-probe (Sprint 0043 T-0257). Container port
+      # is always 8001 (see MCP_PORT below).
+      - "${BRILLIANT_MCP_PORT:-8011}:8001"
     volumes:
       - ./mcp:/app
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,13 @@ services:
       # Fall back to canonical defaults when install.sh did not run.
       MCP_BASE_URL: ${MCP_BASE_URL:-http://localhost:8011}
       API_BASE_URL: ${API_BASE_URL:-http://localhost:8010}
+      # /setup display-URL resolvers (api/routes/setup.py::_mcp_url_for_display)
+      # read these directly; install.sh writes them to .env but compose must
+      # forward them into the container or the route falls back to :8011/:8010.
+      BRILLIANT_MCP_PUBLIC_URL: ${BRILLIANT_MCP_PUBLIC_URL:-}
+      BRILLIANT_API_PUBLIC_URL: ${BRILLIANT_API_PUBLIC_URL:-}
+      BRILLIANT_MCP_PORT: ${BRILLIANT_MCP_PORT:-}
+      BRILLIANT_API_PORT: ${BRILLIANT_API_PORT:-}
       # Shared HMAC secret for /oauth/login → /oauth/continue handoff. Must
       # match the MCP service's value. install.sh mints one into .env on
       # fresh installs (Sprint 0044 follow-up); Render generates+shares via

--- a/install.sh
+++ b/install.sh
@@ -654,6 +654,13 @@ phase_env() {
   set_env_var BRILLIANT_MCP_PORT "$MCP_HOST_PORT" "./.env"
   set_env_var MCP_BASE_URL       "$MCP_URL"       "./.env"
   set_env_var API_BASE_URL       "$API_URL"       "./.env"
+  # Canonical names read by api/routes/setup.py::_mcp_url_for_display and
+  # mcp/client.py::_resolve_api_base_url. Without these, the /credentials
+  # page (and stdio MCP client) fall back to the hardcoded localhost:8011 /
+  # localhost:8010 defaults — which don't match the probed ports when the
+  # installer bumps to :8020/:8021 or higher.
+  set_env_var BRILLIANT_MCP_PUBLIC_URL "$MCP_URL" "./.env"
+  set_env_var BRILLIANT_API_PUBLIC_URL "$API_URL" "./.env"
 
   # Sprint 0043 T-0259 — mint a pwd-derived COMPOSE_PROJECT_NAME so two
   # installs on the same host land in distinct compose projects (distinct

--- a/install.sh
+++ b/install.sh
@@ -98,6 +98,26 @@ rand_password() {
   openssl rand -base64 "$1" | tr -d '=+/' | cut -c1-"$1"
 }
 
+# ---------- compose project naming (Sprint 0043 T-0259) ----------
+
+compute_compose_project_name() {
+  # Deterministic compose project name derived from the install dir's
+  # absolute path. Fixes the T-0259 collision: compose's default project
+  # name is the parent-dir basename, so every self-clone into the default
+  # `./xireactor-brilliant` dir resolved to the same project `xireactor-
+  # brilliant`. Two such installs on one host would share container names
+  # and the `pgdata` volume prefix, causing `docker compose up` to
+  # recreate the sibling stack against a mismatched `.env` password.
+  #
+  # The hash is sha256 truncated to 8 hex chars, derived via openssl
+  # (already a hard dep) so we don't rely on `sha1sum` / `md5sum` (GNU-
+  # only) or `shasum` (mac-only).
+  local path hash
+  path="$(pwd)"
+  hash="$(printf '%s' "$path" | openssl dgst -sha256 | awk '{print $NF}' | cut -c1-8)"
+  printf 'brilliant-%s' "$hash"
+}
+
 # ---------- port probing (Sprint 0043 T-0257) ----------
 
 port_in_use() {
@@ -509,6 +529,16 @@ phase_env() {
   set_env_var MCP_BASE_URL       "$MCP_URL"       "./.env"
   set_env_var API_BASE_URL       "$API_URL"       "./.env"
 
+  # Sprint 0043 T-0259 — mint a pwd-derived COMPOSE_PROJECT_NAME so two
+  # installs on the same host land in distinct compose projects (distinct
+  # container names, distinct `pgdata` volume). Without this, `docker
+  # compose up` in a second install RECREATES the first install's
+  # containers against a mismatched `.env`.
+  local project_name
+  project_name="$(compute_compose_project_name)"
+  set_env_var COMPOSE_PROJECT_NAME "$project_name" "./.env"
+  log "phase 5" "compose project: ${project_name} (derived from $(pwd))"
+
   chmod 600 "./.env"
   log "phase 5" ".env generated at ./.env (mode 600)"
 }
@@ -690,14 +720,17 @@ phase_seed() {
     die 84 "demo seed file not found at ${seed_path} — is this the brilliant repo?"
   fi
 
-  # Pipe the SQL into the running brilliant-db container. We do NOT cd into
-  # the container or bind-mount the file — `docker exec -i` + STDIN redirect
-  # is portable and does not need any compose-file changes.
+  # Pipe the SQL into the db service via `docker compose exec -T`. Post-
+  # T-0259 we no longer hardcode `container_name: brilliant-db` in
+  # docker-compose.yml, so `docker exec brilliant-db` would miss the
+  # container (it's now named ${COMPOSE_PROJECT_NAME}-db-1). Compose-exec
+  # resolves the service regardless of the project's container-name
+  # scheme. `-T` disables TTY allocation so the `<` redirect works.
   local pg_user pg_db
   pg_user="${POSTGRES_USER:-postgres}"
   pg_db="${POSTGRES_DB:-brilliant}"
 
-  if ! docker exec -i brilliant-db psql -U "$pg_user" -d "$pg_db" \
+  if ! docker compose exec -T db psql -U "$pg_user" -d "$pg_db" \
         -v ON_ERROR_STOP=1 < "$seed_path" 2>&1 | tee -a "$LOG_FILE"; then
     log "phase 6b" "demo seed psql failed — dumping db logs"
     docker compose logs db --tail 30 2>&1 | tee -a "$LOG_FILE" || true
@@ -788,10 +821,19 @@ phase_migrate_from_cortex() {
   log "migrate" "step 4: remove old cortex containers (data volume preserved)"
   run_cmd docker rm -f cortex-db cortex-api cortex-mcp
 
-  # Step 5: bring up the renamed stack. docker-compose.yml on this branch
-  # already names the containers brilliant-*.
-  log "migrate" "step 5: docker compose up -d --build (brilliant-*)"
+  # Step 5: bring up the renamed stack. Post-T-0259 docker-compose.yml no
+  # longer hardcodes `container_name:`, so we also mint a pwd-derived
+  # COMPOSE_PROJECT_NAME into `.env` before `docker compose up` — keeps
+  # migrated installs from colliding with any sibling brilliant checkout
+  # on the same host.
+  log "migrate" "step 5: docker compose up -d --build"
   if [ "$DRY_RUN" -eq 0 ]; then
+    if [ -f "./.env" ]; then
+      local project_name
+      project_name="$(compute_compose_project_name)"
+      set_env_var COMPOSE_PROJECT_NAME "$project_name" "./.env"
+      log "migrate" "compose project: ${project_name}"
+    fi
     docker compose up -d --build 2>&1 | tee -a "$LOG_FILE"
   else
     log "migrate" "\$ docker compose up -d --build"
@@ -813,24 +855,28 @@ phase_migrate_from_cortex() {
       docker compose logs api --tail 50 2>&1 | tee -a "$LOG_FILE" || true
       die 78 "brilliant-api did not become healthy within ${HEALTH_TIMEOUT_SECONDS}s after migration. See ${LOG_FILE}."
     fi
-    if ! docker exec brilliant-db psql -U postgres -lqt | grep -q '\bbrilliant\b'; then
-      die 79 "brilliant database not found inside brilliant-db after migration. See ${LOG_FILE}."
+    # Post-T-0259: use `docker compose exec db` — no literal brilliant-db
+    # container name after we dropped `container_name:` from compose.
+    if ! docker compose exec -T db psql -U postgres -lqt | grep -q '\bbrilliant\b'; then
+      die 79 "brilliant database not found inside db service after migration. See ${LOG_FILE}."
     fi
-    log "migrate" "brilliant database present in brilliant-db"
+    log "migrate" "brilliant database present in db service"
   else
     log "migrate" "\$ curl -fsS ${API_URL}/health  (poll up to ${HEALTH_TIMEOUT_SECONDS}s)"
-    log "migrate" "\$ docker exec brilliant-db psql -U postgres -lqt | grep brilliant"
+    log "migrate" "\$ docker compose exec -T db psql -U postgres -lqt | grep brilliant"
   fi
 
   # Step 7: summary.
   log "migrate" "step 7: summary"
+  local summary_project
+  summary_project="$(compute_compose_project_name)"
   cat <<MIGRATED
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   Migrated cortex → brilliant. Data preserved.
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  New containers: brilliant-db, brilliant-api, brilliant-mcp
+  New services:   db, api, mcp (compose project: ${summary_project})
   Database:       brilliant (renamed from cortex, same data volume)
   API:            ${API_URL}
 

--- a/install.sh
+++ b/install.sh
@@ -29,12 +29,19 @@ MCP_HOST_PORT="${DEFAULT_MCP_PORT}"
 API_URL="http://localhost:${API_HOST_PORT}"
 MCP_URL="http://localhost:${MCP_HOST_PORT}"
 readonly LOG_FILE="./install.log"
-readonly DEFAULT_KEY_OUT="./brilliant-credentials.txt"
+# Sprint 0044 T-0260 — installer no longer writes a credentials file by
+# default. The path below is only used by the headless-with-admin branch
+# (`--admin-email` + `--admin-password`), where `fetch_credentials_file`
+# curls `GET /credentials` after admin bootstrap and writes the six-field
+# block alongside the installer.
+readonly CREDENTIALS_FILE="./brilliant-credentials.txt"
 readonly HEALTH_TIMEOUT_SECONDS=60
-# shellcheck disable=SC2034
-readonly VERIFY_TIMEOUT_SECONDS=30
-# shellcheck disable=SC2034
 readonly POLL_INTERVAL_SECONDS=2
+# Window for the post-health admin-bootstrap to flush credentials into the
+# DB. `phase_up` returns as soon as `/health` is green, but the bootstrap
+# task can land a couple of seconds later — `fetch_credentials_file`
+# retries `GET /credentials` over this window before giving up.
+readonly CREDENTIALS_FETCH_TIMEOUT_SECONDS=15
 # Port-probe tuning: step size and maximum number of attempts per port.
 # 5 attempts at +10 each → 5442→5452→5462→5472→5482, then error out.
 readonly PORT_PROBE_STEP=10
@@ -44,15 +51,16 @@ readonly PORT_PROBE_MAX_TRIES=5
 
 ADMIN_EMAIL=""
 ADMIN_PASSWORD=""
+ADMIN_PASSWORD_FROM_ARGV=0
 ADMIN_API_KEY=""
 POSTGRES_PASSWORD=""
 ANTHROPIC_API_KEY=""
-KEY_OUT="${DEFAULT_KEY_OUT}"
 FORCE=0
 NO_INSTALL_DOCKER=0
 DRY_RUN=0
 MIGRATE_FROM_CORTEX=0
 SEED_DEMO=0
+HEADLESS=0
 REF=""
 REF_EXPLICIT=0
 CLONE_DIR="${DEFAULT_CLONE_DIR}"
@@ -90,12 +98,6 @@ mask() {
 rand_hex() {
   # $1 byte count — openssl rand -hex gives 2*N hex chars
   openssl rand -hex "$1"
-}
-
-rand_password() {
-  # URL-safe printable: base64 then strip padding/slashes/plus.
-  # $1 byte count (resulting string length >= ~$1 chars).
-  openssl rand -base64 "$1" | tr -d '=+/' | cut -c1-"$1"
 }
 
 # ---------- compose project naming (Sprint 0043 T-0259) ----------
@@ -183,35 +185,6 @@ phase_port_probe() {
   fi
 }
 
-# ---------- path helpers ----------
-
-absolutize_path() {
-  # Convert a (potentially relative) path to an absolute path anchored at
-  # the current working directory. Does NOT require the path to exist yet
-  # — we may be resolving $KEY_OUT before it has been written. We resolve
-  # the parent directory (which does exist, since write_key_out checks for
-  # it) and append the basename. Works on Mac + Linux without realpath.
-  # $1 path
-  local path="$1"
-  case "$path" in
-    /*) printf '%s' "$path" ;;  # already absolute
-    *)
-      local dir base
-      dir="$(dirname "$path")"
-      base="$(basename "$path")"
-      # cd into the dir in a subshell so we don't pollute the caller's cwd.
-      if [ -d "$dir" ]; then
-        printf '%s/%s' "$(cd "$dir" && pwd)" "$base"
-      else
-        # Parent doesn't exist (yet). Fall back to $PWD join — caller
-        # will later fail the dir-check in write_key_out with a clear
-        # error, which is the right behavior.
-        printf '%s/%s' "$(pwd)" "$path"
-      fi
-      ;;
-  esac
-}
-
 # ---------- help ----------
 
 print_help() {
@@ -221,19 +194,36 @@ xiReactor Brilliant installer
 Usage:
   install.sh [flags]
 
-Required:
-  --admin-email EMAIL        Admin user email (used for login + bootstrap).
+Default (browser ceremony, no flags):
+  Stand up the stack, open /setup in your browser, exit. You complete
+  the form in the browser and download brilliant-credentials.txt from
+  the response page. No credentials file is written by the installer.
 
 Optional:
-  --admin-password PW        Admin password. Random if unset.
+  --headless, --no-browser   Skip the browser auto-open. Print the /setup
+                             URL with an SSH-tunnel hint so a VPS operator
+                             can complete the ceremony from their workstation
+                             over a forwarded port.
+  --admin-email EMAIL        Headless install (VPS / CI / scripted). When set,
+                             the installer writes ADMIN_EMAIL to .env, the
+                             admin user is bootstrapped on API boot, and after
+                             health-check the installer auto-writes
+                             ./brilliant-credentials.txt by curling
+                             /credentials with the minted admin key.
+                             Implies --headless. Pair with --admin-password.
+  --admin-password PW        Admin password for the headless path. When omitted
+                             alongside --admin-email on a TTY, the installer
+                             prompts for it interactively (read -s, double-entry
+                             confirm). Passing it on argv triggers a stderr
+                             warning — the value is visible in `ps` and shell
+                             history. Use the interactive form unless scripting.
   --admin-api-key KEY        Admin API key. Random (bkai_<hex>) if unset.
+                             Only consumed on the headless-with-admin path.
   --postgres-password PW     Postgres password. Random if unset.
   --anthropic-api-key KEY    Anthropic key for Tier 3 reviewer (opt-in).
-  --key-out PATH             Write admin API key to PATH (mode 600).
-                             Default: ./brilliant-credentials.txt
   --force                    Overwrite existing .env.
   --no-install-docker        Detect Docker only; fail if missing.
-  --dry-run                  Print the 8-phase plan and exit 0.
+  --dry-run                  Print the install plan and exit 0.
   --migrate-from-cortex      Upgrade a pre-rename cortex-* stack in place:
                              rename the cortex DB to brilliant, tear down old
                              containers, and bring up the renamed stack with
@@ -254,9 +244,17 @@ Optional:
   -h, --help                 Show this message.
 
 Examples:
+  # Default — browser opens to /setup.
+  ./install.sh
+
+  # Headless VPS, SSH-tunnel persona — installer prints the /setup URL.
+  ./install.sh --headless
+
+  # Headless scripted — installer writes brilliant-credentials.txt on its own.
+  ./install.sh --admin-email you@example.com --admin-password 's3cret!'
+
+  # Headless interactive — same as above but prompts for the password.
   ./install.sh --admin-email you@example.com
-  ./install.sh --admin-email you@example.com --key-out /tmp/key.txt
-  ./install.sh --dry-run --admin-email test@x.com
 
 HELP
 }
@@ -268,16 +266,15 @@ parse_flags() {
     case "$1" in
       --admin-email)         ADMIN_EMAIL="${2:-}"; shift 2 ;;
       --admin-email=*)       ADMIN_EMAIL="${1#*=}"; shift ;;
-      --admin-password)      ADMIN_PASSWORD="${2:-}"; shift 2 ;;
-      --admin-password=*)    ADMIN_PASSWORD="${1#*=}"; shift ;;
+      --admin-password)      ADMIN_PASSWORD="${2:-}"; ADMIN_PASSWORD_FROM_ARGV=1; shift 2 ;;
+      --admin-password=*)    ADMIN_PASSWORD="${1#*=}"; ADMIN_PASSWORD_FROM_ARGV=1; shift ;;
       --admin-api-key)       ADMIN_API_KEY="${2:-}"; shift 2 ;;
       --admin-api-key=*)     ADMIN_API_KEY="${1#*=}"; shift ;;
       --postgres-password)   POSTGRES_PASSWORD="${2:-}"; shift 2 ;;
       --postgres-password=*) POSTGRES_PASSWORD="${1#*=}"; shift ;;
       --anthropic-api-key)   ANTHROPIC_API_KEY="${2:-}"; shift 2 ;;
       --anthropic-api-key=*) ANTHROPIC_API_KEY="${1#*=}"; shift ;;
-      --key-out)             KEY_OUT="${2:-}"; shift 2 ;;
-      --key-out=*)           KEY_OUT="${1#*=}"; shift ;;
+      --headless|--no-browser) HEADLESS=1; shift ;;
       --force)               FORCE=1; shift ;;
       --no-install-docker)   NO_INSTALL_DOCKER=1; shift ;;
       --dry-run)             DRY_RUN=1; shift ;;
@@ -291,6 +288,121 @@ parse_flags() {
       *) die 64 "Unknown flag: $1 (try --help)" ;;
     esac
   done
+}
+
+# ---------- admin-flag validation + interactive password (Sprint 0044 T-0260) ----------
+
+validate_admin_flags() {
+  # Reject obvious nonsense before we touch the filesystem:
+  #   --admin-password without --admin-email is meaningless (no admin to
+  #   own the password) and tends to mask a typo.
+  if [ -z "$ADMIN_EMAIL" ] && [ -n "$ADMIN_PASSWORD" ]; then
+    die 64 "--admin-password requires --admin-email (no admin user to bind it to)"
+  fi
+}
+
+prompt_admin_password() {
+  # Headless-with-admin path. Only fires when --admin-email is set.
+  #   - If --admin-password was passed on argv: emit a one-line stderr
+  #     warning ("visible in ps / shell history — prefer interactive
+  #     entry") and return. CI escape valve.
+  #   - Else if stdin is a TTY: read -s twice with a confirm. Mismatch
+  #     dies (exit 64) without echoing either attempt.
+  #   - Else (non-TTY, no argv password): die with a clear message
+  #     telling the caller to pass --admin-password (or run on a TTY).
+  if [ -z "$ADMIN_EMAIL" ]; then
+    return 0
+  fi
+  if [ "$ADMIN_PASSWORD_FROM_ARGV" -eq 1 ]; then
+    printf 'WARNING: --admin-password on argv is visible in ps/shell history; prefer interactive entry.\n' >&2
+    return 0
+  fi
+  if [ ! -t 0 ]; then
+    die 64 "--admin-email passed but --admin-password is missing and stdin is not a TTY. Pass --admin-password explicitly or run interactively."
+  fi
+  local p1 p2
+  printf 'Admin password: ' >&2
+  IFS= read -rs p1 || die 64 "failed to read admin password"
+  printf '\n' >&2
+  printf 'Confirm:        ' >&2
+  IFS= read -rs p2 || die 64 "failed to read admin password confirmation"
+  printf '\n' >&2
+  if [ -z "$p1" ]; then
+    die 64 "admin password must not be empty"
+  fi
+  if [ "$p1" != "$p2" ]; then
+    die 64 "admin passwords did not match"
+  fi
+  ADMIN_PASSWORD="$p1"
+}
+
+# ---------- browser-open + credentials fetch (Sprint 0044 T-0260) ----------
+
+open_browser() {
+  # Best-effort browser open for the default ceremony path. Never fails the
+  # installer — if neither `open` (mac) nor `xdg-open` (linux) is present
+  # (e.g. bare-shell VPS that the user forgot to flag --headless on), the
+  # caller's URL-print fallback is the recovery surface.
+  local url="$1"
+  if command -v open >/dev/null 2>&1; then
+    open "$url" >/dev/null 2>&1 &
+    return 0
+  fi
+  if command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$url" >/dev/null 2>&1 &
+    return 0
+  fi
+  return 1
+}
+
+fetch_credentials_file() {
+  # Headless-with-admin only. After admin bootstrap has flushed credentials
+  # to the DB, curl `GET /credentials` with the minted admin key and write
+  # the six-field shape to ./brilliant-credentials.txt (mode 600). Retries
+  # over CREDENTIALS_FETCH_TIMEOUT_SECONDS to tolerate slow bootstrap (the
+  # /health probe in phase_up is satisfied before lifespan finishes).
+  local path="$CREDENTIALS_FILE"
+  local waited=0
+  local tmp
+  tmp="$(mktemp)"
+  # shellcheck disable=SC2064
+  trap "rm -f '$tmp'" RETURN
+  while [ "$waited" -lt "$CREDENTIALS_FETCH_TIMEOUT_SECONDS" ]; do
+    if curl -fsS \
+        -H "Authorization: Bearer ${ADMIN_API_KEY}" \
+        -H "Accept: application/json" \
+        "${API_URL}/credentials" -o "$tmp" 2>/dev/null; then
+      # Re-format JSON → six `key=value` lines. No jq dep — grep + sed
+      # parse works because the response body is a flat object emitted by
+      # FastAPI's JSONResponse.
+      {
+        for k in admin_email admin_api_key oauth_client_id oauth_client_secret mcp_url login_url; do
+          local v
+          v="$(grep -oE "\"${k}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$tmp" | sed -E "s/.*\"${k}\"[[:space:]]*:[[:space:]]*\"([^\"]*)\".*/\1/")"
+          printf '%s=%s\n' "$k" "$v"
+        done
+      } >"$path"
+      chmod 600 "$path"
+      log "phase 8" "credentials written to ${path} (mode 600, six fields)"
+      return 0
+    fi
+    sleep "$POLL_INTERVAL_SECONDS"
+    waited=$((waited + POLL_INTERVAL_SECONDS))
+  done
+
+  # Don't fail the installer — admin is up, the user just has to recover
+  # the file manually. Print the recovery snippet so they have it to hand.
+  log "phase 8" "WARN: /credentials fetch did not succeed within ${CREDENTIALS_FETCH_TIMEOUT_SECONDS}s"
+  cat >&2 <<RECOVER
+WARNING: failed to write ${CREDENTIALS_FILE}. The stack is healthy and the
+admin user is bootstrapped. To re-fetch the credentials block manually:
+
+  curl -H "Authorization: Bearer ${ADMIN_API_KEY}" \\
+       ${API_URL}/credentials > ${CREDENTIALS_FILE}
+  chmod 600 ${CREDENTIALS_FILE}
+
+RECOVER
+  return 1
 }
 
 # ---------- preflight ----------
@@ -331,10 +443,18 @@ phase_preflight() {
 # ---------- randoms fill ----------
 
 phase_randoms() {
+  # POSTGRES_PASSWORD is always randomized — compose needs it on every path
+  # and it's not user-facing. ADMIN_API_KEY is minted only on the headless-
+  # with-admin path so `fetch_credentials_file` can curl /credentials with
+  # a known Bearer; on the default browser-ceremony path the key is minted
+  # by the API at /setup time and delivered to the browser. ADMIN_PASSWORD
+  # is never auto-generated — `prompt_admin_password` already required the
+  # operator to provide one if they're on the headless-with-admin path.
   log "phase 4" "resolving randoms for unset values"
   : "${POSTGRES_PASSWORD:=$(rand_hex 24)}"
-  : "${ADMIN_PASSWORD:=$(rand_password 24)}"
-  : "${ADMIN_API_KEY:=bkai_$(rand_hex 24)}"
+  if [ -n "$ADMIN_EMAIL" ]; then
+    : "${ADMIN_API_KEY:=bkai_$(rand_hex 24)}"
+  fi
 }
 
 # ---------- phase stubs (filled in by later tasks) ----------
@@ -509,9 +629,15 @@ phase_env() {
   cp "./.env.sample" "./.env"
 
   set_env_var POSTGRES_PASSWORD "$POSTGRES_PASSWORD" "./.env"
-  set_env_var ADMIN_EMAIL       "$ADMIN_EMAIL"       "./.env"
-  set_env_var ADMIN_PASSWORD    "$ADMIN_PASSWORD"    "./.env"
-  set_env_var ADMIN_API_KEY     "$ADMIN_API_KEY"     "./.env"
+  # Sprint 0044 T-0260 — ADMIN_* are only written when the operator opted
+  # into the headless-with-admin path (--admin-email + --admin-password).
+  # On the default path these stay empty and `ensure_admin_user` no-ops,
+  # leaving the `/setup` web ceremony as the single admin-claim path.
+  if [ -n "$ADMIN_EMAIL" ]; then
+    set_env_var ADMIN_EMAIL    "$ADMIN_EMAIL"    "./.env"
+    set_env_var ADMIN_PASSWORD "$ADMIN_PASSWORD" "./.env"
+    set_env_var ADMIN_API_KEY  "$ADMIN_API_KEY"  "./.env"
+  fi
   if [ -n "$ANTHROPIC_API_KEY" ]; then
     set_env_var ANTHROPIC_API_KEY "$ANTHROPIC_API_KEY" "./.env"
   fi
@@ -563,128 +689,88 @@ phase_up() {
   die 3 "API did not become healthy within ${HEALTH_TIMEOUT_SECONDS}s. See ${LOG_FILE}."
 }
 
-phase_verify() {
-  log "phase 7" "verifying admin API key against ${API_URL}/entries"
-  local waited=0
-  local http_code
-  while [ "$waited" -lt "$VERIFY_TIMEOUT_SECONDS" ]; do
-    http_code="$(curl -s -o /dev/null -w '%{http_code}' \
-      -H "Authorization: Bearer ${ADMIN_API_KEY}" \
-      "${API_URL}/entries" || true)"
-    if [ "$http_code" = "200" ]; then
-      log "phase 7" "admin key verified (HTTP 200 on /entries)"
-      return 0
-    fi
-    sleep "$POLL_INTERVAL_SECONDS"
-    waited=$((waited + POLL_INTERVAL_SECONDS))
-  done
-
-  log "phase 7" "admin verify failed after ${VERIFY_TIMEOUT_SECONDS}s (last status: ${http_code:-n/a})"
-  docker compose logs api --tail 50 2>&1 | tee -a "$LOG_FILE" || true
-  die 4 "Admin API key did not authenticate within ${VERIFY_TIMEOUT_SECONDS}s. See ${LOG_FILE}."
-}
-
-extract_credentials_block() {
-  # Scrape the machine-parseable credential block emitted by
-  # api/admin_bootstrap.py between ===BRILLIANT_CREDENTIALS_BEGIN=== and
-  # ===BRILLIANT_CREDENTIALS_END=== markers from the api container logs.
-  # Prints the inner block (six `key=value` lines) to stdout on success,
-  # or nothing on failure.
-  #
-  # Note: admin bootstrap runs exactly once at first boot, so the block
-  # will be present in the full container log history. We use `--no-color`
-  # to avoid ANSI escape noise when future loggers add color.
-  docker compose logs --no-color api 2>/dev/null \
-    | awk '
-        /===BRILLIANT_CREDENTIALS_BEGIN===/ { inblk=1; next }
-        /===BRILLIANT_CREDENTIALS_END===/   { inblk=0 }
-        inblk {
-          # docker-compose log lines look like:
-          #   brilliant-api  | admin_email=foo@bar.com
-          # Strip the "containername ... | " prefix (the pipe is
-          # reliable). Fall back to the whole line if no pipe is found
-          # (older compose formats or custom formatters).
-          pipe = index($0, "|")
-          if (pipe > 0) {
-            line = substr($0, pipe + 1)
-            sub(/^[[:space:]]+/, "", line)
-          } else {
-            line = $0
-          }
-          if (line ~ /^[a-z_]+=/) print line
-        }
-      ' \
-    | tail -n 6
-}
-
-write_key_out() {
-  # Write the six-field credential block to $1 (mode 600). Fields are
-  # extracted from `docker compose logs api` via extract_credentials_block;
-  # when the scrape fails (e.g. logs rolled, DRY_RUN, or bootstrap hit the
-  # latch on a re-run), fall back to the in-memory ADMIN_API_KEY + email so
-  # the install still produces a credentials file — just a thinner one.
-  local path="$1"
-  local dir
-  dir="$(dirname "$path")"
-  if [ ! -d "$dir" ]; then
-    die 75 "key-out directory does not exist: $dir"
-  fi
-
-  local block
-  block="$(extract_credentials_block || true)"
-  # Count non-empty key=value lines.
-  local line_count=0
-  if [ -n "$block" ]; then
-    line_count="$(printf '%s\n' "$block" | grep -c '=')"
-  fi
-
-  {
-    if [ "$line_count" -ge 6 ]; then
-      printf '%s\n' "$block"
-    else
-      # Fallback path — bootstrap block not found (log rolled, already
-      # bootstrapped, etc). Emit what we have; downstream tooling can
-      # still read admin_email + admin_api_key.
-      printf 'admin_email=%s\n'     "$ADMIN_EMAIL"
-      printf 'admin_api_key=%s\n'   "$ADMIN_API_KEY"
-      printf 'oauth_client_id=%s\n'     ""
-      printf 'oauth_client_secret=%s\n' ""
-      printf 'mcp_url=%s\n'         "${MCP_URL}"
-      printf 'login_url=%s\n'       "${API_URL}/auth/login"
-    fi
-  } >"$path"
-  chmod 600 "$path"
-}
-
 phase_summary() {
-  log "phase 8" "writing credentials to ${KEY_OUT}"
-  write_key_out "$KEY_OUT"
+  # Three branches keyed off (HEADLESS, ADMIN_EMAIL):
+  #   - default ceremony (HEADLESS=0, no ADMIN_EMAIL): browser auto-open,
+  #     /setup CTA, no creds file written.
+  #   - headless no-admin (HEADLESS=1, no ADMIN_EMAIL): URL-print +
+  #     SSH-tunnel hint, no browser-open, no creds file.
+  #   - headless with admin (ADMIN_EMAIL set; HEADLESS implicit): no
+  #     browser-open, no /setup CTA (latch is already claimed by env-
+  #     bootstrap), creds file auto-written via fetch_credentials_file.
+  #
+  # The Services + Stop blocks are identical across branches.
 
-  # The banner prints to stdout only (not the log) — this is what the
-  # operator reads at the end of a successful run. Sprint 0043 #42 reshape:
-  # lead with /setup + /import/vault (the URLs that actually matter to a
-  # first-run user), show the absolute Key file path so it resolves after
-  # the installer exits from any CWD, and document the stop / full-reset
-  # off-ramps so there's no "how do I turn this off?" guesswork.
+  local mode
+  if [ -n "$ADMIN_EMAIL" ]; then
+    mode="headless-with-admin"
+  elif [ "$HEADLESS" -eq 1 ]; then
+    mode="headless"
+  else
+    mode="default"
+  fi
+  log "phase 8" "summary mode: ${mode}"
+
+  # Headless-with-admin writes the creds file BEFORE the banner so the
+  # banner can reference its presence (or absence on the warning path).
+  if [ "$mode" = "headless-with-admin" ]; then
+    fetch_credentials_file || true
+  fi
+
   cat <<BANNER
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   xiReactor Brilliant installed successfully
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  Next steps — open these in a browser:
-    Setup:        ${API_URL}/setup
-    Import vault: ${API_URL}/import/vault
+BANNER
 
-  Credentials file (contains 6 fields — keep it safe):
-    ${KEY_OUT} (mode 600)
+  case "$mode" in
+    default)
+      cat <<NEXT
+  Next steps:
+    Your browser should be opening to:
+      ${API_URL}/setup
 
+    If it doesn't open automatically, paste the URL above into your
+    browser. Complete the form, then download brilliant-credentials.txt
+    from the response page.
+
+NEXT
+      ;;
+    headless)
+      cat <<NEXT
+  Next steps (headless / SSH-tunnel):
+    Complete setup in your browser at:
+      ${API_URL}/setup
+
+    On a remote VPS, forward the API port to your workstation first:
+      ssh -L ${API_HOST_PORT}:localhost:${API_HOST_PORT} user@host
+
+    then open the URL above on your workstation.
+
+NEXT
+      ;;
+    headless-with-admin)
+      cat <<NEXT
+  Credentials (admin bootstrapped via env):
+    File:         ${CREDENTIALS_FILE} (mode 600, six fields)
+    Admin email:  ${ADMIN_EMAIL}
+
+    To re-fetch this file later:
+      curl -H 'Authorization: Bearer <admin_api_key>' \\
+           ${API_URL}/credentials > ${CREDENTIALS_FILE}
+
+NEXT
+      ;;
+  esac
+
+  cat <<SERVICES
   Services:
     API:          ${API_URL}
     Health:       ${API_URL}/health
     MCP:          ${MCP_URL}
     Postgres:     localhost:${DB_HOST_PORT}
-    Admin email:  ${ADMIN_EMAIL}
 
   Stop / reset:
     docker compose down           # stop containers (preserves data)
@@ -692,7 +778,14 @@ phase_summary() {
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-BANNER
+SERVICES
+
+  # Default-mode browser-open is best-effort and runs after the banner so
+  # the user sees the fallback URL even if the open command swallows the
+  # event (e.g. no display server but `xdg-open` exits 0).
+  if [ "$mode" = "default" ]; then
+    open_browser "${API_URL}/setup" || true
+  fi
 }
 
 # ---------- demo seed (opt-in via --seed-demo) ----------
@@ -892,16 +985,26 @@ MIGRATED
 # ---------- dry-run plan ----------
 
 print_plan() {
+  local mode
+  if [ -n "$ADMIN_EMAIL" ]; then
+    mode="headless-with-admin (env-driven bootstrap + auto-written ${CREDENTIALS_FILE})"
+  elif [ "$HEADLESS" -eq 1 ]; then
+    mode="headless (URL-print, no browser-open, /setup ceremony in browser)"
+  else
+    mode="default (browser auto-open to /setup, no installer-written creds file)"
+  fi
   cat <<PLAN
 xiReactor Brilliant installer — dry-run plan (v${SCRIPT_VERSION})
 
+Install mode: ${mode}
+
 Resolved configuration:
-  admin-email:        ${ADMIN_EMAIL:-(required — none)}
+  admin-email:        ${ADMIN_EMAIL:-(unset — default ceremony path)}
   admin-password:     $(mask "${ADMIN_PASSWORD}")
   admin-api-key:      $(mask "${ADMIN_API_KEY}")
   postgres-password:  $(mask "${POSTGRES_PASSWORD}")
   anthropic-api-key:  $(mask "${ANTHROPIC_API_KEY}")
-  key-out:            ${KEY_OUT}
+  headless:           ${HEADLESS}
   force:              ${FORCE}
   no-install-docker:  ${NO_INSTALL_DOCKER}
   seed-demo:          ${SEED_DEMO}
@@ -913,13 +1016,14 @@ Planned phases:
   [phase 1b] self-clone  — if not inside a brilliant repo, git clone --ref into --dir and cd in
   [phase 2]  docker      — detect; install Colima (Mac) or get.docker.com (Linux) if missing
   [phase 3]  repo        — confirm we're inside the brilliant repo (docker-compose.yml present)
-  [phase 4]  randoms     — fill unset secrets via openssl rand
+  [phase 4]  randoms     — fill unset secrets via openssl rand (ADMIN_API_KEY only when --admin-email is set)
   [phase 4b] port-probe  — probe db/api/mcp host ports; shift by ${PORT_PROBE_STEP} up to ${PORT_PROBE_MAX_TRIES} tries on conflict
   [phase 5]  env         — write ./.env from .env.sample (mode 600); refuse overwrite without --force
+                          ADMIN_EMAIL/PASSWORD/API_KEY written only on the headless-with-admin path
   [phase 6]  up          — docker compose up -d, poll ${API_URL}/health for up to ${HEALTH_TIMEOUT_SECONDS}s
   [phase 6b] seed        — if --seed-demo: pipe db/seed/demo.sql through docker exec psql (skipped otherwise)
-  [phase 7]  verify      — GET ${API_URL}/entries with admin key to confirm bootstrap
-  [phase 8]  summary     — print banner, write key to ${KEY_OUT} (mode 600)
+  [phase 8]  summary     — print mode-specific banner; on default path open ${API_URL}/setup in the browser;
+                          on headless-with-admin path curl ${API_URL}/credentials → ${CREDENTIALS_FILE} (mode 600)
 
 PLAN
 }
@@ -929,19 +1033,16 @@ PLAN
 main() {
   parse_flags "$@"
 
-  # Resolve KEY_OUT to an absolute path BEFORE any `cd` into the self-
-  # cloned repo. This is load-bearing for two reasons:
-  #   1. The final banner prints $KEY_OUT and the operator often `cat`s it
-  #      from a different working directory — a relative path would break.
-  #   2. phase_self_clone cd's into $CLONE_DIR; a relative KEY_OUT would
-  #      silently end up inside the clone dir rather than beside the
-  #      installer invocation.
-  KEY_OUT="$(absolutize_path "$KEY_OUT")"
-
-  # --migrate-from-cortex is a dedicated upgrade path and does not require
-  # --admin-email — the admin user already exists in the preserved DB.
-  if [ "$MIGRATE_FROM_CORTEX" -eq 0 ] && [ -z "$ADMIN_EMAIL" ]; then
-    die 64 "--admin-email is required (try --help)"
+  # Sprint 0044 T-0260 — install no longer requires --admin-email. Default
+  # path stands the stack up and points the operator at `/setup`. The only
+  # required validation is the orphan check (--admin-password without
+  # --admin-email) and the headless-with-admin password prompt.
+  validate_admin_flags
+  if [ "$MIGRATE_FROM_CORTEX" -eq 0 ] && [ -n "$ADMIN_EMAIL" ]; then
+    # Implicit: passing --admin-email switches the installer into the
+    # headless scripted path (no browser-open, auto-write creds file).
+    HEADLESS=1
+    prompt_admin_password
   fi
 
   if [ "$MIGRATE_FROM_CORTEX" -eq 1 ]; then
@@ -966,8 +1067,9 @@ main() {
   if [ "$DRY_RUN" -eq 1 ]; then
     # Fill resolved randoms in memory so the plan masks sensibly — silently.
     : "${POSTGRES_PASSWORD:=$(rand_hex 24)}"
-    : "${ADMIN_PASSWORD:=$(rand_password 24)}"
-    : "${ADMIN_API_KEY:=bkai_$(rand_hex 24)}"
+    if [ -n "$ADMIN_EMAIL" ]; then
+      : "${ADMIN_API_KEY:=bkai_$(rand_hex 24)}"
+    fi
     print_plan
     exit 0
   fi
@@ -984,7 +1086,6 @@ main() {
   phase_port_probe
   phase_env
   phase_up
-  phase_verify
   phase_seed
   phase_summary
 }

--- a/install.sh
+++ b/install.sh
@@ -10,14 +10,24 @@ set -euo pipefail
 # Constants are consumed across phases; shellcheck can't see forward into
 # function bodies that arrive in later tasks (T-0176/T-0177). Suppress the
 # false-positive unused warnings at the declaration site.
-readonly SCRIPT_VERSION="0.4.0"
+readonly SCRIPT_VERSION="0.5.1"
 readonly DEFAULT_CLONE_DIR="./xireactor-brilliant"
 readonly REPO_SLUG="thejeremyhodge/xireactor-brilliant"
-readonly API_URL="http://localhost:8010"
-# shellcheck disable=SC2034
-readonly MCP_URL="http://localhost:8011"
-# shellcheck disable=SC2034
-readonly PG_HOST_PORT="5442"
+# Default host ports — overridden by phase_port_probe if occupied. These
+# are the ports advertised in README/docs; single-install flows on a clean
+# machine preserve them verbatim. Sprint 0043 T-0257.
+readonly DEFAULT_DB_PORT=5442
+readonly DEFAULT_API_PORT=8010
+readonly DEFAULT_MCP_PORT=8011
+# Chosen ports (populated by phase_port_probe). Kept as non-readonly so
+# the probe can mutate them in place. URLs below are derived from these.
+DB_HOST_PORT="${DEFAULT_DB_PORT}"
+API_HOST_PORT="${DEFAULT_API_PORT}"
+MCP_HOST_PORT="${DEFAULT_MCP_PORT}"
+# URLs re-derived after phase_port_probe. (Legacy PG_HOST_PORT alias
+# was removed in T-0257 — every call site now reads DB_HOST_PORT.)
+API_URL="http://localhost:${API_HOST_PORT}"
+MCP_URL="http://localhost:${MCP_HOST_PORT}"
 readonly LOG_FILE="./install.log"
 readonly DEFAULT_KEY_OUT="./brilliant-credentials.txt"
 readonly HEALTH_TIMEOUT_SECONDS=60
@@ -25,6 +35,10 @@ readonly HEALTH_TIMEOUT_SECONDS=60
 readonly VERIFY_TIMEOUT_SECONDS=30
 # shellcheck disable=SC2034
 readonly POLL_INTERVAL_SECONDS=2
+# Port-probe tuning: step size and maximum number of attempts per port.
+# 5 attempts at +10 each → 5442→5452→5462→5472→5482, then error out.
+readonly PORT_PROBE_STEP=10
+readonly PORT_PROBE_MAX_TRIES=5
 
 # ---------- flag defaults ----------
 
@@ -38,6 +52,7 @@ FORCE=0
 NO_INSTALL_DOCKER=0
 DRY_RUN=0
 MIGRATE_FROM_CORTEX=0
+SEED_DEMO=0
 REF=""
 REF_EXPLICIT=0
 CLONE_DIR="${DEFAULT_CLONE_DIR}"
@@ -83,6 +98,100 @@ rand_password() {
   openssl rand -base64 "$1" | tr -d '=+/' | cut -c1-"$1"
 }
 
+# ---------- port probing (Sprint 0043 T-0257) ----------
+
+port_in_use() {
+  # Returns 0 (true) if TCP port $1 on localhost is occupied, 1 otherwise.
+  # Primary: `lsof -i :$port` (standard on Mac + most Linux distros).
+  # Fallback: `nc -z localhost $port` (BusyBox / slim containers).
+  # Both are silent on success/failure; we only care about the exit code.
+  local port="$1"
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -i ":${port}" -sTCP:LISTEN >/dev/null 2>&1
+    return $?
+  fi
+  if command -v nc >/dev/null 2>&1; then
+    nc -z localhost "${port}" >/dev/null 2>&1
+    return $?
+  fi
+  # No probe tool available — assume the port is free. Better to try the
+  # bind than to spuriously fail before docker compose ever runs.
+  return 1
+}
+
+probe_port() {
+  # Given a "friendly name" $1 and a starting port $2, return the first
+  # free port in the sequence start, start+10, start+20, ... up to
+  # PORT_PROBE_MAX_TRIES attempts. Prints the chosen port to stdout.
+  # Fails (exit non-zero) if every candidate in range is occupied.
+  local label="$1"
+  local start="$2"
+  local attempt=0
+  local port="$start"
+  while [ "$attempt" -lt "$PORT_PROBE_MAX_TRIES" ]; do
+    if ! port_in_use "$port"; then
+      printf '%d' "$port"
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    port=$((start + attempt * PORT_PROBE_STEP))
+  done
+  die 86 "port-probe: all ${PORT_PROBE_MAX_TRIES} candidate ${label} ports occupied starting at ${start} (step ${PORT_PROBE_STEP}). Free a port or re-run after closing the conflicting service."
+}
+
+phase_port_probe() {
+  # Pick host ports for db/api/mcp — default values unless occupied. On a
+  # clean machine with nothing else bound, this is a no-op (each probe
+  # returns the default immediately) so single-install flows stay
+  # byte-identical to pre-0043 behavior.
+  log "phase 4b" "probing host ports (db=${DEFAULT_DB_PORT}, api=${DEFAULT_API_PORT}, mcp=${DEFAULT_MCP_PORT})"
+  DB_HOST_PORT="$(probe_port db "$DEFAULT_DB_PORT")"
+  API_HOST_PORT="$(probe_port api "$DEFAULT_API_PORT")"
+  MCP_HOST_PORT="$(probe_port mcp "$DEFAULT_MCP_PORT")"
+
+  # Re-derive downstream URLs so everything (health poll, verify,
+  # banner, credentials file) reads the chosen values.
+  API_URL="http://localhost:${API_HOST_PORT}"
+  MCP_URL="http://localhost:${MCP_HOST_PORT}"
+
+  if [ "$DB_HOST_PORT" != "$DEFAULT_DB_PORT" ] \
+      || [ "$API_HOST_PORT" != "$DEFAULT_API_PORT" ] \
+      || [ "$MCP_HOST_PORT" != "$DEFAULT_MCP_PORT" ]; then
+    log "phase 4b" "port conflict resolved: db=${DB_HOST_PORT}, api=${API_HOST_PORT}, mcp=${MCP_HOST_PORT}"
+  else
+    log "phase 4b" "all default ports free"
+  fi
+}
+
+# ---------- path helpers ----------
+
+absolutize_path() {
+  # Convert a (potentially relative) path to an absolute path anchored at
+  # the current working directory. Does NOT require the path to exist yet
+  # — we may be resolving $KEY_OUT before it has been written. We resolve
+  # the parent directory (which does exist, since write_key_out checks for
+  # it) and append the basename. Works on Mac + Linux without realpath.
+  # $1 path
+  local path="$1"
+  case "$path" in
+    /*) printf '%s' "$path" ;;  # already absolute
+    *)
+      local dir base
+      dir="$(dirname "$path")"
+      base="$(basename "$path")"
+      # cd into the dir in a subshell so we don't pollute the caller's cwd.
+      if [ -d "$dir" ]; then
+        printf '%s/%s' "$(cd "$dir" && pwd)" "$base"
+      else
+        # Parent doesn't exist (yet). Fall back to $PWD join — caller
+        # will later fail the dir-check in write_key_out with a clear
+        # error, which is the right behavior.
+        printf '%s/%s' "$(pwd)" "$path"
+      fi
+      ;;
+  esac
+}
+
 # ---------- help ----------
 
 print_help() {
@@ -109,6 +218,12 @@ Optional:
                              rename the cortex DB to brilliant, tear down old
                              containers, and bring up the renamed stack with
                              the existing data volume preserved.
+  --seed-demo                Opt in to the demo dataset (4 demo users, 12
+                             entries, links/versions/staging/audit rows).
+                             Applied via `docker exec` after the stack is
+                             healthy. Every seeded entry carries the
+                             `demo:seed` tag; remove later with
+                             `python tools/remove_demo_data.py --yes`.
   --ref REF                  Git ref (tag, branch, or sha) to clone when the
                              installer is not already inside a brilliant repo.
                              Default: latest release tag, or `main` if the
@@ -147,6 +262,7 @@ parse_flags() {
       --no-install-docker)   NO_INSTALL_DOCKER=1; shift ;;
       --dry-run)             DRY_RUN=1; shift ;;
       --migrate-from-cortex) MIGRATE_FROM_CORTEX=1; shift ;;
+      --seed-demo)           SEED_DEMO=1; shift ;;
       --ref)                 REF="${2:-}"; REF_EXPLICIT=1; shift 2 ;;
       --ref=*)               REF="${1#*=}"; REF_EXPLICIT=1; shift ;;
       --dir)                 CLONE_DIR="${2:-}"; shift 2 ;;
@@ -380,6 +496,19 @@ phase_env() {
     set_env_var ANTHROPIC_API_KEY "$ANTHROPIC_API_KEY" "./.env"
   fi
 
+  # Sprint 0043 T-0257 — thread chosen host ports + derived URLs into
+  # `.env`. docker-compose.yml reads BRILLIANT_{DB,API,MCP}_PORT via
+  # ${…:-default} so a clean install (no conflict) preserves the
+  # historical 5442/8010/8011 binding exactly. MCP_BASE_URL +
+  # API_BASE_URL are also written so admin_bootstrap's credential-block
+  # emitter picks up the chosen URLs (it reads these env vars and falls
+  # back to localhost:8010/8011 otherwise — see api/admin_bootstrap.py).
+  set_env_var BRILLIANT_DB_PORT  "$DB_HOST_PORT"  "./.env"
+  set_env_var BRILLIANT_API_PORT "$API_HOST_PORT" "./.env"
+  set_env_var BRILLIANT_MCP_PORT "$MCP_HOST_PORT" "./.env"
+  set_env_var MCP_BASE_URL       "$MCP_URL"       "./.env"
+  set_env_var API_BASE_URL       "$API_URL"       "./.env"
+
   chmod 600 "./.env"
   log "phase 5" ".env generated at ./.env (mode 600)"
 }
@@ -425,45 +554,156 @@ phase_verify() {
   die 4 "Admin API key did not authenticate within ${VERIFY_TIMEOUT_SECONDS}s. See ${LOG_FILE}."
 }
 
+extract_credentials_block() {
+  # Scrape the machine-parseable credential block emitted by
+  # api/admin_bootstrap.py between ===BRILLIANT_CREDENTIALS_BEGIN=== and
+  # ===BRILLIANT_CREDENTIALS_END=== markers from the api container logs.
+  # Prints the inner block (six `key=value` lines) to stdout on success,
+  # or nothing on failure.
+  #
+  # Note: admin bootstrap runs exactly once at first boot, so the block
+  # will be present in the full container log history. We use `--no-color`
+  # to avoid ANSI escape noise when future loggers add color.
+  docker compose logs --no-color api 2>/dev/null \
+    | awk '
+        /===BRILLIANT_CREDENTIALS_BEGIN===/ { inblk=1; next }
+        /===BRILLIANT_CREDENTIALS_END===/   { inblk=0 }
+        inblk {
+          # docker-compose log lines look like:
+          #   brilliant-api  | admin_email=foo@bar.com
+          # Strip the "containername ... | " prefix (the pipe is
+          # reliable). Fall back to the whole line if no pipe is found
+          # (older compose formats or custom formatters).
+          pipe = index($0, "|")
+          if (pipe > 0) {
+            line = substr($0, pipe + 1)
+            sub(/^[[:space:]]+/, "", line)
+          } else {
+            line = $0
+          }
+          if (line ~ /^[a-z_]+=/) print line
+        }
+      ' \
+    | tail -n 6
+}
+
 write_key_out() {
+  # Write the six-field credential block to $1 (mode 600). Fields are
+  # extracted from `docker compose logs api` via extract_credentials_block;
+  # when the scrape fails (e.g. logs rolled, DRY_RUN, or bootstrap hit the
+  # latch on a re-run), fall back to the in-memory ADMIN_API_KEY + email so
+  # the install still produces a credentials file — just a thinner one.
   local path="$1"
   local dir
   dir="$(dirname "$path")"
   if [ ! -d "$dir" ]; then
     die 75 "key-out directory does not exist: $dir"
   fi
-  printf '%s\n' "$ADMIN_API_KEY" >"$path"
+
+  local block
+  block="$(extract_credentials_block || true)"
+  # Count non-empty key=value lines.
+  local line_count=0
+  if [ -n "$block" ]; then
+    line_count="$(printf '%s\n' "$block" | grep -c '=')"
+  fi
+
+  {
+    if [ "$line_count" -ge 6 ]; then
+      printf '%s\n' "$block"
+    else
+      # Fallback path — bootstrap block not found (log rolled, already
+      # bootstrapped, etc). Emit what we have; downstream tooling can
+      # still read admin_email + admin_api_key.
+      printf 'admin_email=%s\n'     "$ADMIN_EMAIL"
+      printf 'admin_api_key=%s\n'   "$ADMIN_API_KEY"
+      printf 'oauth_client_id=%s\n'     ""
+      printf 'oauth_client_secret=%s\n' ""
+      printf 'mcp_url=%s\n'         "${MCP_URL}"
+      printf 'login_url=%s\n'       "${API_URL}/auth/login"
+    fi
+  } >"$path"
   chmod 600 "$path"
 }
 
 phase_summary() {
-  log "phase 8" "writing admin key to ${KEY_OUT}"
+  log "phase 8" "writing credentials to ${KEY_OUT}"
   write_key_out "$KEY_OUT"
 
-  # The banner prints to stdout only (not the log) — this is what Jeremy reads
-  # at the end of a successful run.
+  # The banner prints to stdout only (not the log) — this is what the
+  # operator reads at the end of a successful run. Sprint 0043 #42 reshape:
+  # lead with /setup + /import/vault (the URLs that actually matter to a
+  # first-run user), show the absolute Key file path so it resolves after
+  # the installer exits from any CWD, and document the stop / full-reset
+  # off-ramps so there's no "how do I turn this off?" guesswork.
   cat <<BANNER
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   xiReactor Brilliant installed successfully
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-  API:           ${API_URL}
-  Health:        ${API_URL}/health
-  MCP:           ${MCP_URL}
-  Postgres:      localhost:${PG_HOST_PORT}
+  Next steps — open these in a browser:
+    Setup:        ${API_URL}/setup
+    Import vault: ${API_URL}/import/vault
 
-  Admin email:   ${ADMIN_EMAIL}
-  Admin key:     ${ADMIN_API_KEY}
-  Key file:      ${KEY_OUT} (mode 600)
+  Credentials file (contains 6 fields — keep it safe):
+    ${KEY_OUT} (mode 600)
 
-  Next steps:
-    curl -H "Authorization: Bearer \$(cat ${KEY_OUT})" ${API_URL}/entries
-    See README.md → "Connect Claude" to wire up the MCP.
+  Services:
+    API:          ${API_URL}
+    Health:       ${API_URL}/health
+    MCP:          ${MCP_URL}
+    Postgres:     localhost:${DB_HOST_PORT}
+    Admin email:  ${ADMIN_EMAIL}
+
+  Stop / reset:
+    docker compose down           # stop containers (preserves data)
+    docker compose down -v        # full reset (drops Postgres volume)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 BANNER
+}
+
+# ---------- demo seed (opt-in via --seed-demo) ----------
+
+phase_seed() {
+  # Apply db/seed/demo.sql via `docker exec` into brilliant-db. This runs
+  # AFTER phase_up (stack healthy) and AFTER phase_verify (admin user is
+  # bootstrapped) so the seed's ON CONFLICT DO NOTHING on org_demo just
+  # accepts the operator-chosen org name instead of overwriting it.
+  #
+  # We deliberately do NOT route seed SQL through the Postgres init-scripts
+  # bind-mount (db/migrations/ → /docker-entrypoint-initdb.d) — see
+  # docker-compose.yml comment on that mount. Keeping the seed out of the
+  # init path means a clean `docker compose up -d` NEVER re-seeds, and
+  # stray files can't auto-run.
+  if [ "$SEED_DEMO" -eq 0 ]; then
+    log "phase 6b" "demo seed disabled (no --seed-demo) — skipping"
+    return 0
+  fi
+
+  log "phase 6b" "applying demo seed (--seed-demo) via docker exec"
+
+  local seed_path="./db/seed/demo.sql"
+  if [ ! -f "$seed_path" ]; then
+    die 84 "demo seed file not found at ${seed_path} — is this the brilliant repo?"
+  fi
+
+  # Pipe the SQL into the running brilliant-db container. We do NOT cd into
+  # the container or bind-mount the file — `docker exec -i` + STDIN redirect
+  # is portable and does not need any compose-file changes.
+  local pg_user pg_db
+  pg_user="${POSTGRES_USER:-postgres}"
+  pg_db="${POSTGRES_DB:-brilliant}"
+
+  if ! docker exec -i brilliant-db psql -U "$pg_user" -d "$pg_db" \
+        -v ON_ERROR_STOP=1 < "$seed_path" 2>&1 | tee -a "$LOG_FILE"; then
+    log "phase 6b" "demo seed psql failed — dumping db logs"
+    docker compose logs db --tail 30 2>&1 | tee -a "$LOG_FILE" || true
+    die 85 "demo seed failed to apply. See ${LOG_FILE}. Stack is healthy; remove demo rows (if any applied) with: python tools/remove_demo_data.py --yes"
+  fi
+  log "phase 6b" "demo seed applied (12 entries tagged 'demo:seed')"
 }
 
 # ---------- migration: cortex → brilliant ----------
@@ -618,6 +858,7 @@ Resolved configuration:
   key-out:            ${KEY_OUT}
   force:              ${FORCE}
   no-install-docker:  ${NO_INSTALL_DOCKER}
+  seed-demo:          ${SEED_DEMO}
   ref:                ${REF:-(latest release tag; fallback main)}
   dir:                ${CLONE_DIR}
 
@@ -627,8 +868,10 @@ Planned phases:
   [phase 2]  docker      — detect; install Colima (Mac) or get.docker.com (Linux) if missing
   [phase 3]  repo        — confirm we're inside the brilliant repo (docker-compose.yml present)
   [phase 4]  randoms     — fill unset secrets via openssl rand
+  [phase 4b] port-probe  — probe db/api/mcp host ports; shift by ${PORT_PROBE_STEP} up to ${PORT_PROBE_MAX_TRIES} tries on conflict
   [phase 5]  env         — write ./.env from .env.sample (mode 600); refuse overwrite without --force
   [phase 6]  up          — docker compose up -d, poll ${API_URL}/health for up to ${HEALTH_TIMEOUT_SECONDS}s
+  [phase 6b] seed        — if --seed-demo: pipe db/seed/demo.sql through docker exec psql (skipped otherwise)
   [phase 7]  verify      — GET ${API_URL}/entries with admin key to confirm bootstrap
   [phase 8]  summary     — print banner, write key to ${KEY_OUT} (mode 600)
 
@@ -639,6 +882,15 @@ PLAN
 
 main() {
   parse_flags "$@"
+
+  # Resolve KEY_OUT to an absolute path BEFORE any `cd` into the self-
+  # cloned repo. This is load-bearing for two reasons:
+  #   1. The final banner prints $KEY_OUT and the operator often `cat`s it
+  #      from a different working directory — a relative path would break.
+  #   2. phase_self_clone cd's into $CLONE_DIR; a relative KEY_OUT would
+  #      silently end up inside the clone dir rather than beside the
+  #      installer invocation.
+  KEY_OUT="$(absolutize_path "$KEY_OUT")"
 
   # --migrate-from-cortex is a dedicated upgrade path and does not require
   # --admin-email — the admin user already exists in the preserved DB.
@@ -683,9 +935,11 @@ main() {
   phase_docker
   phase_repo
   phase_randoms
+  phase_port_probe
   phase_env
   phase_up
   phase_verify
+  phase_seed
   phase_summary
 }
 

--- a/install.sh
+++ b/install.sh
@@ -124,20 +124,22 @@ compute_compose_project_name() {
 
 port_in_use() {
   # Returns 0 (true) if TCP port $1 on localhost is occupied, 1 otherwise.
-  # Primary: `lsof -i :$port` (standard on Mac + most Linux distros).
-  # Fallback: `nc -z localhost $port` (BusyBox / slim containers).
-  # Both are silent on success/failure; we only care about the exit code.
+  # Tries lsof (fast, works on Mac / Docker Desktop) then nc (catches
+  # Linux Docker Engine setups where port-forwarding is a DNAT rule and
+  # no listening socket exists for lsof to see). Either positive wins.
   local port="$1"
   if command -v lsof >/dev/null 2>&1; then
-    lsof -i ":${port}" -sTCP:LISTEN >/dev/null 2>&1
-    return $?
+    if lsof -i ":${port}" -sTCP:LISTEN >/dev/null 2>&1; then
+      return 0
+    fi
   fi
   if command -v nc >/dev/null 2>&1; then
-    nc -z localhost "${port}" >/dev/null 2>&1
-    return $?
+    if nc -z localhost "${port}" >/dev/null 2>&1; then
+      return 0
+    fi
   fi
-  # No probe tool available — assume the port is free. Better to try the
-  # bind than to spuriously fail before docker compose ever runs.
+  # No probe saw it occupied — treat as free. Better to try the bind than
+  # to spuriously fail before docker compose ever runs.
   return 1
 }
 

--- a/mcp/remote_server.py
+++ b/mcp/remote_server.py
@@ -48,6 +48,116 @@ from tools import register_tools
 
 logger = logging.getLogger("brilliant.auth")
 
+
+# ---------------------------------------------------------------------------
+# RFC 6749 §2.3.1 Basic-auth bridge for /token
+# ---------------------------------------------------------------------------
+#
+# FastMCP's stock token handler validates the POST body twice — once in
+# `ClientAuthenticator.authenticate_request` for client credentials, once
+# in `AuthorizationCodeRequest` (pydantic) for grant fields — and BOTH
+# layers require `client_id` to be present as a form field. Spec-compliant
+# clients (e.g. `mcp-remote`) using `client_secret_basic` put credentials
+# in the Authorization header and MAY omit them from the form per RFC 6749
+# §2.3.1, which causes 401 "Missing client_id" and then the cosmetic
+# downstream "No code verifier saved for session" from mcp-remote's retry.
+#
+# We fix this at the ASGI edge: when `POST /token` arrives with an
+# `Authorization: Basic …` header and the urlencoded body lacks
+# `client_id` / `client_secret`, we decode the header and inject those
+# fields into the body before any FastMCP handler sees the request. Both
+# validation layers then see a well-formed POST-body form. Co-work's
+# POST-body flow is untouched (it never trips the "missing" branch).
+class _BasicAuthTokenBodyBridge:
+    """ASGI middleware that bridges Basic-auth /token requests to POST-body form."""
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if (
+            scope.get("type") != "http"
+            or scope.get("method") != "POST"
+            or scope.get("path") != "/token"
+        ):
+            await self.app(scope, receive, send)
+            return
+
+        raw_headers = scope.get("headers") or []
+        header_lookup = {k: v for k, v in raw_headers}
+        auth = header_lookup.get(b"authorization", b"")
+        ctype = header_lookup.get(b"content-type", b"").decode("latin-1", "replace")
+        if not auth.startswith(b"Basic ") or "application/x-www-form-urlencoded" not in ctype:
+            await self.app(scope, receive, send)
+            return
+
+        import base64 as _b64
+        import binascii as _binascii
+        from urllib.parse import parse_qsl, unquote, urlencode
+
+        try:
+            decoded = _b64.b64decode(auth[6:]).decode("utf-8")
+            if ":" not in decoded:
+                raise ValueError("Basic auth missing ':' separator")
+            raw_id, raw_secret = decoded.split(":", 1)
+            basic_id = unquote(raw_id)
+            basic_secret = unquote(raw_secret)
+        except (ValueError, UnicodeDecodeError, _binascii.Error):
+            # Malformed Basic — let the downstream handler emit its own error.
+            await self.app(scope, receive, send)
+            return
+
+        body = bytearray()
+        more = True
+        while more:
+            msg = await receive()
+            body.extend(msg.get("body", b""))
+            more = msg.get("more_body", False)
+        body_bytes = bytes(body)
+
+        pairs = parse_qsl(
+            body_bytes.decode("utf-8", "replace"),
+            keep_blank_values=True,
+        )
+        keys = {k for k, _ in pairs}
+        mutated = False
+        if "client_id" not in keys:
+            pairs.append(("client_id", basic_id))
+            mutated = True
+        if "client_secret" not in keys:
+            pairs.append(("client_secret", basic_secret))
+            mutated = True
+
+        if not mutated:
+            new_body = body_bytes
+            new_headers = raw_headers
+        else:
+            new_body = urlencode(pairs).encode("utf-8")
+            new_headers = [
+                (k, v) for k, v in raw_headers if k != b"content-length"
+            ]
+            new_headers.append(
+                (b"content-length", str(len(new_body)).encode("latin-1"))
+            )
+
+        new_scope = dict(scope)
+        new_scope["headers"] = new_headers
+
+        sent = False
+
+        async def replay_receive():
+            nonlocal sent
+            if not sent:
+                sent = True
+                return {
+                    "type": "http.request",
+                    "body": new_body,
+                    "more_body": False,
+                }
+            return await receive()
+
+        await self.app(new_scope, replay_receive, send)
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -669,8 +779,11 @@ def create_app():
         expose_headers=["mcp-session-id"],
         allow_credentials=True,
     )
+    app.add_middleware(_BasicAuthTokenBodyBridge)
     return app
 
 
 if __name__ == "__main__":
-    mcp.run(transport="streamable-http")
+    import uvicorn
+
+    uvicorn.run(create_app(), host="0.0.0.0", port=MCP_PORT)

--- a/tests/test_basic_auth_bridge.py
+++ b/tests/test_basic_auth_bridge.py
@@ -1,0 +1,339 @@
+"""Unit tests for ``_BasicAuthTokenBodyBridge`` ASGI middleware (T-0263).
+
+The middleware lives in ``mcp/remote_server.py`` and intercepts
+``POST /token`` requests carrying ``Authorization: Basic`` credentials.
+It decodes the header and injects ``client_id`` / ``client_secret`` into
+the urlencoded form body before FastMCP's two POST-body validators
+(``ClientAuthenticator``, ``AuthorizationCodeRequest``) see the request.
+RFC 6749 §2.3.1 clients (e.g. ``mcp-remote``) put credentials in the
+header and MAY omit them from the body — without this bridge FastMCP
+401s them. See ST-0208 for the incident that motivated the fix.
+
+The scenarios below exercise the middleware with a minimal ASGI harness
+(fake scope / receive / send, in-process downstream recorder). No DB,
+no network, no FastMCP.
+
+Run modes:
+  - pytest (host, with mcp[cli] SDK installed):
+      pytest tests/test_basic_auth_bridge.py -v
+  - Standalone (inside the mcp container where pytest is absent):
+      docker cp tests/test_basic_auth_bridge.py <mcp-ct>:/tmp/
+      docker exec <mcp-ct> python3 /tmp/test_basic_auth_bridge.py
+
+Blocks commit of the ST-0208 fix (middleware + ``uvicorn.run(create_app())``
+entry flip in mcp/remote_server.py).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import inspect
+import sys
+import traceback
+from pathlib import Path
+from urllib.parse import parse_qsl
+
+# Make the bridge importable. When running on the host the module lives
+# at ``<repo>/mcp/remote_server.py``; inside the container the file is
+# at ``/app/remote_server.py`` and cwd is already ``/app``. Either way
+# we add the directory to sys.path so ``from remote_server import …``
+# resolves, and Python's `mcp` package (the SDK) keeps resolving from
+# site-packages because we do not add the repo root.
+_THIS = Path(__file__).resolve()
+_CANDIDATES = [
+    _THIS.parent.parent / "mcp",  # host-layout
+    Path("/app"),                  # in-container layout
+]
+for _cand in _CANDIDATES:
+    if _cand.is_dir() and str(_cand) not in sys.path:
+        sys.path.insert(0, str(_cand))
+
+try:
+    from remote_server import _BasicAuthTokenBodyBridge  # noqa: E402
+    _BRIDGE_AVAILABLE = True
+    _IMPORT_ERROR: str | None = None
+except Exception as exc:  # noqa: BLE001 — surface any import failure to the skip reason
+    _BRIDGE_AVAILABLE = False
+    _IMPORT_ERROR = f"{type(exc).__name__}: {exc}"
+
+
+try:
+    import pytest  # type: ignore[import-not-found]
+
+    pytestmark = pytest.mark.skipif(
+        not _BRIDGE_AVAILABLE,
+        reason=(
+            "mcp/remote_server.py not importable — requires mcp[cli] SDK "
+            f"(pip install -r mcp/requirements.txt). Import error: {_IMPORT_ERROR}"
+        ),
+    )
+except ImportError:
+    pytest = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# ASGI harness
+# ---------------------------------------------------------------------------
+
+
+class _AppRecorder:
+    """Downstream ASGI app that records the scope + fully-drained body."""
+
+    def __init__(self) -> None:
+        self.scope: dict | None = None
+        self.body: bytes = b""
+        self.called: bool = False
+
+    async def __call__(self, scope, receive, send) -> None:
+        self.called = True
+        self.scope = scope
+        chunks: list[bytes] = []
+        more = True
+        while more:
+            msg = await receive()
+            chunks.append(msg.get("body", b""))
+            more = msg.get("more_body", False)
+        self.body = b"".join(chunks)
+
+
+def _build_receive(body_chunks: list[bytes]):
+    """Build an async ``receive`` that emits the given chunks then stops."""
+    pending = list(enumerate(body_chunks))
+
+    async def receive():
+        if not pending:
+            return {"type": "http.request", "body": b"", "more_body": False}
+        idx, chunk = pending.pop(0)
+        more_body = idx < len(body_chunks) - 1
+        return {"type": "http.request", "body": chunk, "more_body": more_body}
+
+    return receive
+
+
+async def _noop_send(_msg) -> None:
+    return None
+
+
+def _basic(raw: bytes) -> bytes:
+    """Build a well-formed ``Authorization: Basic <b64>`` value."""
+    return b"Basic " + base64.b64encode(raw)
+
+
+def _make_scope(
+    *,
+    method: str = "POST",
+    path: str = "/token",
+    authorization: bytes | None = None,
+    content_type: bytes | None = b"application/x-www-form-urlencoded",
+    body_len: int | None = None,
+) -> dict:
+    if authorization is None:
+        authorization = _basic(b"client-xyz:secret-abc")
+    headers: list[tuple[bytes, bytes]] = []
+    if authorization is not False:  # explicit False means "omit"
+        headers.append((b"authorization", authorization))
+    if content_type is not None:
+        headers.append((b"content-type", content_type))
+    if body_len is not None:
+        headers.append((b"content-length", str(body_len).encode("latin-1")))
+    return {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": headers,
+    }
+
+
+def _run_bridge(scope: dict, body_chunks: list[bytes]) -> _AppRecorder:
+    recorder = _AppRecorder()
+    bridge = _BasicAuthTokenBodyBridge(recorder)
+    asyncio.run(bridge(scope, _build_receive(body_chunks), _noop_send))
+    return recorder
+
+
+def _header(recorder: _AppRecorder, name: bytes) -> bytes | None:
+    assert recorder.scope is not None
+    for k, v in recorder.scope["headers"]:
+        if k == name:
+            return v
+    return None
+
+
+def _form(body: bytes) -> dict[str, str]:
+    return dict(parse_qsl(body.decode("utf-8"), keep_blank_values=True))
+
+
+# ---------------------------------------------------------------------------
+# Happy path — the scenarios the bridge was written for
+# ---------------------------------------------------------------------------
+
+
+def test_basic_header_empty_body_injects_credentials():
+    """POST /token + Basic + empty form body → body gains client_id+secret."""
+    scope = _make_scope(body_len=0)
+    rec = _run_bridge(scope, [b""])
+
+    assert rec.called
+    assert _form(rec.body) == {
+        "client_id": "client-xyz",
+        "client_secret": "secret-abc",
+    }
+    # Content-Length must be rewritten to match the mutated body.
+    assert _header(rec, b"content-length") == str(len(rec.body)).encode("latin-1")
+
+
+def test_basic_header_preserves_existing_grant_fields():
+    """Existing grant_type/code fields survive; credentials appended."""
+    body = b"grant_type=authorization_code&code=abc123&redirect_uri=http%3A%2F%2Flocal"
+    scope = _make_scope(body_len=len(body))
+    rec = _run_bridge(scope, [body])
+
+    form = _form(rec.body)
+    assert form["grant_type"] == "authorization_code"
+    assert form["code"] == "abc123"
+    assert form["redirect_uri"] == "http://local"
+    assert form["client_id"] == "client-xyz"
+    assert form["client_secret"] == "secret-abc"
+
+
+def test_body_with_existing_client_id_not_overwritten():
+    """Body's client_id wins over Basic's; missing secret still injected."""
+    body = b"client_id=from-body&grant_type=authorization_code"
+    scope = _make_scope(body_len=len(body))
+    rec = _run_bridge(scope, [body])
+
+    form = _form(rec.body)
+    assert form["client_id"] == "from-body"
+    assert form["client_secret"] == "secret-abc"
+
+
+def test_body_with_both_credentials_present_is_unchanged():
+    """Nothing to inject → body bytes pass through exactly."""
+    body = b"client_id=x&client_secret=y&grant_type=refresh_token"
+    scope = _make_scope(body_len=len(body))
+    rec = _run_bridge(scope, [body])
+
+    assert rec.body == body
+    # Headers untouched too — original content-length preserved.
+    assert _header(rec, b"content-length") == str(len(body)).encode("latin-1")
+
+
+def test_multi_chunk_body_is_drained_and_replayed_as_one():
+    """Streaming body chunks → bridge concatenates, then replays single chunk."""
+    chunks = [b"grant_type=", b"authorization_code", b"&code=xyz"]
+    scope = _make_scope(body_len=sum(len(c) for c in chunks))
+    rec = _run_bridge(scope, chunks)
+
+    form = _form(rec.body)
+    assert form["grant_type"] == "authorization_code"
+    assert form["code"] == "xyz"
+    assert form["client_id"] == "client-xyz"
+    assert form["client_secret"] == "secret-abc"
+
+
+def test_urlencoded_basic_credentials_are_percent_decoded():
+    """RFC 7617 — Basic-auth userinfo may be percent-encoded."""
+    scope = _make_scope(
+        authorization=_basic(b"client%3Aid:secret%3Aval"),
+        body_len=0,
+    )
+    rec = _run_bridge(scope, [b""])
+
+    form = _form(rec.body)
+    assert form["client_id"] == "client:id"
+    assert form["client_secret"] == "secret:val"
+
+
+# ---------------------------------------------------------------------------
+# Pass-through — these requests must not be mutated
+# ---------------------------------------------------------------------------
+
+
+def test_non_post_method_passes_through():
+    body = b"client_id=x"
+    scope = _make_scope(method="GET", body_len=len(body))
+    rec = _run_bridge(scope, [body])
+    assert rec.body == body
+
+
+def test_non_token_path_passes_through():
+    body = b"client_id=x"
+    scope = _make_scope(path="/register", body_len=len(body))
+    rec = _run_bridge(scope, [body])
+    assert rec.body == body
+
+
+def test_no_authorization_header_passes_through():
+    body = b"client_id=x&client_secret=y"
+    scope = _make_scope(authorization=False, body_len=len(body))  # type: ignore[arg-type]
+    rec = _run_bridge(scope, [body])
+    assert rec.body == body
+
+
+def test_bearer_authorization_passes_through():
+    body = b"grant_type=refresh_token"
+    scope = _make_scope(
+        authorization=b"Bearer abc.def.ghi",
+        body_len=len(body),
+    )
+    rec = _run_bridge(scope, [body])
+    assert rec.body == body
+
+
+def test_json_content_type_passes_through():
+    """Bridge only handles urlencoded forms — JSON bodies untouched."""
+    body = b'{"client_id":"x"}'
+    scope = _make_scope(
+        content_type=b"application/json",
+        body_len=len(body),
+    )
+    rec = _run_bridge(scope, [body])
+    assert rec.body == body
+
+
+def test_malformed_basic_no_colon_passes_through():
+    """Decoded userinfo missing ':' separator → bridge gives up silently."""
+    scope = _make_scope(
+        authorization=_basic(b"no-colon-here"),
+        body_len=0,
+    )
+    rec = _run_bridge(scope, [b""])
+    assert rec.body == b""
+    assert "client_id" not in _form(rec.body)
+
+
+# ---------------------------------------------------------------------------
+# Standalone runner — invoked when pytest is not available (e.g. inside
+# the mcp container). Mirrors the minimal runner in mcp/test_remote.py.
+# ---------------------------------------------------------------------------
+
+
+def _main() -> int:
+    if not _BRIDGE_AVAILABLE:
+        print(f"SKIP: {_IMPORT_ERROR}")
+        return 0
+
+    mod = sys.modules[__name__]
+    tests = sorted(
+        (name, fn)
+        for name, fn in inspect.getmembers(mod, inspect.isfunction)
+        if name.startswith("test_")
+    )
+    passed = failed = 0
+    for name, fn in tests:
+        try:
+            fn()
+        except Exception:
+            print(f"  FAIL  {name}")
+            traceback.print_exc()
+            failed += 1
+        else:
+            print(f"  PASS  {name}")
+            passed += 1
+    print(f"\n{passed} passed, {failed} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,322 @@
+"""Integration tests for ``GET /credentials`` recovery route.
+
+Sprint 0043, T-0254 — close Issue #45 Option B. Operators who lose
+``brilliant-credentials.txt`` can re-fetch the six-field payload with
+their admin API key. The payload shape matches the installer file
+byte-for-byte so a user can ``curl ... > brilliant-credentials.txt``
+the response and have a drop-in replacement.
+
+Three cases exercised:
+
+  1. Valid admin Bearer → 200 JSON with all six fields present.
+  2. No Authorization header → 401 (enforced by
+     :func:`auth._extract_bearer_token`).
+  3. Non-admin user API key → 403 (enforced by ``_require_admin``
+     inside the handler; auth succeeds, role check fails).
+
+Prerequisites (matches tests/test_service_role.py conventions):
+  1. docker compose up -d   (API on :8010, Postgres on :5442)
+     Migrations through 032 (api_public_url) applied.
+  2. Seed data loaded (005_seed.sql equivalent — demo.sql in v0.5.1+).
+  3. pip install -r tests/requirements-dev.txt
+
+Run:
+  pytest tests/test_credentials.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import time
+from typing import Iterator
+
+import pytest
+import requests
+
+try:
+    import psycopg
+    _PSYCOPG_AVAILABLE = True
+except ImportError:
+    _PSYCOPG_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Configuration (mirrors tests/test_service_role.py)
+# ---------------------------------------------------------------------------
+
+BASE_URL = os.environ.get("BRILLIANT_BASE_URL", "http://localhost:8010")
+DB_DSN = os.environ.get(
+    "BRILLIANT_DB_DSN",
+    "postgresql://postgres:dev@localhost:5442/brilliant",
+)
+REQUEST_TIMEOUT = 10.0
+
+# Seed keys (005_seed.sql / demo.sql) — stable across test runs because
+# /auth/login rotation only touches the admin key, not the editor key.
+ADMIN_KEY = "bkai_adm1_testkey_admin"
+EDITOR_KEY = "bkai_edit_testkey_editor"
+
+
+# ---------------------------------------------------------------------------
+# Skip gates
+# ---------------------------------------------------------------------------
+
+
+def _api_available() -> bool:
+    try:
+        return requests.get(f"{BASE_URL}/health", timeout=2.0).status_code == 200
+    except Exception:
+        return False
+
+
+def _db_available() -> bool:
+    if not _PSYCOPG_AVAILABLE:
+        return False
+    try:
+        with psycopg.connect(DB_DSN, connect_timeout=2) as _:
+            return True
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _api_available(),
+        reason=(
+            f"Brilliant API not reachable at {BASE_URL} "
+            "(start it with `docker compose up -d`)."
+        ),
+    ),
+    pytest.mark.skipif(
+        not _db_available(),
+        reason=(
+            f"Brilliant DB not reachable at {DB_DSN} "
+            "(start it with `docker compose up -d`)."
+        ),
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# OAuth client fixture — seed DB has no oauth_clients row; the recovery
+# route depends on one. Insert a throwaway client for the test, clean up
+# after. Production installs always have exactly one row minted by
+# admin_bootstrap.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def oauth_client_row() -> Iterator[tuple[str, str]]:
+    """Insert a test oauth_clients row, yield ``(client_id, client_secret)``.
+
+    If the caller's admin_bootstrap has already populated the table
+    (fresh docker compose up flows through ensure_admin_user on first
+    boot), we yield the existing row instead of inserting a duplicate.
+    Teardown only deletes rows we inserted.
+    """
+    if not _PSYCOPG_AVAILABLE:
+        pytest.skip("psycopg not installed")
+
+    inserted = False
+    client_id = f"brilliant_test_{secrets.token_hex(8)}"
+    client_secret = secrets.token_hex(32)
+    client_id_issued_at = int(time.time())
+
+    yield_id: str
+    yield_secret: str
+
+    with psycopg.connect(DB_DSN, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            # Prefer the most recently created production row if one
+            # already exists — matches the handler's ORDER BY created_at
+            # DESC LIMIT 1 source-of-truth.
+            cur.execute(
+                """
+                SELECT client_id, client_secret
+                FROM oauth_clients
+                ORDER BY created_at DESC
+                LIMIT 1
+                """
+            )
+            row = cur.fetchone()
+
+            if row is not None:
+                yield_id, yield_secret = str(row[0]), str(row[1])
+            else:
+                cur.execute(
+                    """
+                    INSERT INTO oauth_clients (
+                        client_id, client_secret, client_id_issued_at, client_info
+                    )
+                    VALUES (%s, %s, %s, %s)
+                    """,
+                    (
+                        client_id,
+                        client_secret,
+                        client_id_issued_at,
+                        json.dumps({
+                            "client_id": client_id,
+                            "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+                        }),
+                    ),
+                )
+                inserted = True
+                yield_id, yield_secret = client_id, client_secret
+
+    try:
+        yield (yield_id, yield_secret)
+    finally:
+        if inserted:
+            try:
+                with psycopg.connect(DB_DSN, autocommit=True) as conn:
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            "DELETE FROM oauth_clients WHERE client_id = %s",
+                            (client_id,),
+                        )
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — 200 with valid admin Bearer, all six fields present
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_admin_bearer_returns_six_field_json(
+    oauth_client_row: tuple[str, str],
+):
+    """``GET /credentials`` with a valid admin Bearer must return 200 JSON
+    containing all six canonical fields in the expected shape.
+
+    The six-field contract (see ``api/admin_bootstrap.py``'s credential
+    block + install.sh's writer) is:
+
+      admin_email
+      admin_api_key
+      oauth_client_id
+      oauth_client_secret
+      mcp_url
+      login_url
+
+    admin_api_key should echo the Bearer we presented — that's the only
+    way to put plaintext on the wire, since the DB stores the bcrypt
+    hash. The handler pulls it from request.headers.
+    """
+    r = requests.get(
+        f"{BASE_URL}/credentials",
+        headers={
+            "Authorization": f"Bearer {ADMIN_KEY}",
+            "Accept": "application/json",
+        },
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r.status_code == 200, f"{r.status_code}: {r.text}"
+
+    ctype = r.headers.get("Content-Type", "").lower()
+    assert "application/json" in ctype, (
+        f"expected JSON response, got Content-Type={ctype!r}; body: {r.text!r}"
+    )
+
+    body = r.json()
+    expected_keys = {
+        "admin_email",
+        "admin_api_key",
+        "oauth_client_id",
+        "oauth_client_secret",
+        "mcp_url",
+        "login_url",
+    }
+    assert set(body.keys()) == expected_keys, (
+        f"expected exactly {sorted(expected_keys)}; got {sorted(body.keys())}"
+    )
+
+    # admin_api_key must echo the Bearer we presented (the DB only has
+    # the bcrypt hash, so this is the only way the plaintext can land
+    # in the response).
+    assert body["admin_api_key"] == ADMIN_KEY, (
+        f"expected admin_api_key to echo the Bearer token; got "
+        f"{body['admin_api_key']!r}"
+    )
+
+    # oauth_client_id / oauth_client_secret must match the fixture's
+    # ORDER BY created_at DESC LIMIT 1 pick.
+    expected_client_id, expected_client_secret = oauth_client_row
+    assert body["oauth_client_id"] == expected_client_id, (
+        f"oauth_client_id mismatch: got {body['oauth_client_id']!r}, "
+        f"expected {expected_client_id!r}"
+    )
+    assert body["oauth_client_secret"] == expected_client_secret, (
+        "oauth_client_secret mismatch (plaintext stored in DB per migration 006)"
+    )
+
+    # mcp_url + login_url: loose shape checks — we don't pin values
+    # because they depend on env (RENDER_EXTERNAL_URL) / DB state.
+    assert isinstance(body["mcp_url"], str) and body["mcp_url"], (
+        "mcp_url must be a non-empty string"
+    )
+    assert isinstance(body["login_url"], str) and body["login_url"], (
+        "login_url must be a non-empty string"
+    )
+    assert body["login_url"].endswith("/auth/login"), (
+        f"login_url must end with /auth/login; got {body['login_url']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — 401 without Authorization header
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_without_bearer_returns_401():
+    """``GET /credentials`` with no Authorization header must return 401.
+
+    Enforced by :func:`auth._extract_bearer_token`, which raises
+    HTTPException(401) when the header is absent. This is the same
+    gate every authenticated API route relies on — no special case
+    for /credentials.
+    """
+    r = requests.get(
+        f"{BASE_URL}/credentials",
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r.status_code == 401, (
+        f"expected 401 (no Bearer), got {r.status_code}: {r.text}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — 403 with non-admin user API key
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_non_admin_user_returns_403():
+    """``GET /credentials`` with a valid but non-admin user key must
+    return 403.
+
+    Auth succeeds (the editor seed key bcrypt-verifies), but
+    ``_require_admin`` rejects because role != 'admin'. Error detail
+    should mention "admin" so an operator debugging a failed recovery
+    attempt can tell this from a transient auth failure.
+    """
+    r = requests.get(
+        f"{BASE_URL}/credentials",
+        headers={"Authorization": f"Bearer {EDITOR_KEY}"},
+        timeout=REQUEST_TIMEOUT,
+    )
+    assert r.status_code == 403, (
+        f"expected 403 (non-admin key), got {r.status_code}: {r.text}"
+    )
+
+    # Error detail should surface "admin" so callers can differentiate
+    # from auth failures.
+    detail = ""
+    try:
+        detail = r.json().get("detail", "")
+    except Exception:
+        pass
+    assert "admin" in detail.lower(), (
+        f"expected 'admin' in error detail for clarity; got {detail!r}"
+    )

--- a/tests/test_installer.sh
+++ b/tests/test_installer.sh
@@ -241,4 +241,117 @@ for required_key in admin_email admin_api_key oauth_client_id oauth_client_secre
 done
 
 echo "[smoke] port-conflict scenario PASS"
+
+# ─────────────────────────────────────────────────────────────────────
+# Non-collision scenario (Sprint 0043 T-0259)
+#
+# Goal: two installs in separate dirs must produce independent compose
+# projects — so `docker compose up` in install #B does not RECREATE
+# install #A's containers (which would clobber A's pgdata volume with
+# B's Postgres password → PoolTimeout crashloop).
+#
+# Strategy:
+#   1. Capture install #A's state: COMPOSE_PROJECT_NAME from its .env,
+#      container IDs via `docker compose ps -q`.
+#   2. Copy this checkout to /tmp/bk-alt-$$/xireactor-brilliant (tree
+#      only — no .env, no .git, no install.log). rsync's --exclude is
+#      portable across mac + ubuntu-22.04 CI runners.
+#   3. Run install.sh from the copy. Port-probe shifts off whatever
+#      stack A is holding.
+#   4. Assert:
+#      - Copy's .env has a DIFFERENT COMPOSE_PROJECT_NAME.
+#      - Stack A's container IDs are unchanged (not Recreated).
+#      - Two distinct *_pgdata volumes exist in `docker volume ls`.
+#   5. Tear down stack B (from the copy dir) before the EXIT trap runs.
+# ─────────────────────────────────────────────────────────────────────
+
+echo "[smoke] non-collision scenario: capturing install #A state"
+
+A_PROJECT="$(grep '^COMPOSE_PROJECT_NAME=' ./.env | head -n 1 | cut -d'=' -f2-)"
+if [ -z "$A_PROJECT" ]; then
+  echo "[smoke] FAIL: install #A .env missing COMPOSE_PROJECT_NAME (T-0259)" >&2
+  exit 30
+fi
+A_IDS_BEFORE="$(docker compose ps -q | sort | tr '\n' ' ')"
+if [ -z "$A_IDS_BEFORE" ]; then
+  echo "[smoke] FAIL: install #A has no running containers before sibling install" >&2
+  exit 31
+fi
+echo "[smoke] install #A: project=${A_PROJECT} ids=${A_IDS_BEFORE}"
+
+ALT_ROOT="/tmp/bk-alt-$$"
+ALT_DIR="${ALT_ROOT}/xireactor-brilliant"
+ALT_KEY_FILE="/tmp/brilliant-smoke-alt-key.$$.txt"
+ALT_SUMMARY_FILE="/tmp/brilliant-smoke-alt-summary.$$.txt"
+
+noncollision_cleanup() {
+  # Tear down stack B from its own dir so its project (not A's) is targeted.
+  if [ -d "$ALT_DIR" ] && [ -f "$ALT_DIR/docker-compose.yml" ]; then
+    ( cd "$ALT_DIR" && docker compose down -v 2>/dev/null || true )
+  fi
+  rm -rf "$ALT_ROOT" 2>/dev/null || true
+  rm -f "$ALT_KEY_FILE" "$ALT_SUMMARY_FILE" 2>/dev/null || true
+}
+# Chain: non-collision cleanup → conflict cleanup → baseline cleanup.
+trap 'noncollision_cleanup; conflict_cleanup; cleanup' EXIT
+
+echo "[smoke] copying tree to ${ALT_DIR} for install #B"
+mkdir -p "$ALT_DIR"
+# rsync with exclusions: skip .git (huge), .env + install.log + creds (stale),
+# node_modules if it exists, and any tmp/test artifacts.
+rsync -a \
+  --exclude='.git' \
+  --exclude='.env' \
+  --exclude='install.log' \
+  --exclude='brilliant-credentials.txt' \
+  --exclude='*.pyc' \
+  --exclude='__pycache__' \
+  ./ "$ALT_DIR/"
+
+REPO_DIR="$(pwd)"
+cd "$ALT_DIR"
+
+echo "[smoke] running ./install.sh in ${ALT_DIR} (install #B)"
+./install.sh \
+  --admin-email smoke-alt@example.com \
+  --force \
+  --key-out "$ALT_KEY_FILE" \
+  | tee "$ALT_SUMMARY_FILE"
+
+B_PROJECT="$(grep '^COMPOSE_PROJECT_NAME=' ./.env | head -n 1 | cut -d'=' -f2-)"
+if [ -z "$B_PROJECT" ]; then
+  echo "[smoke] FAIL: install #B .env missing COMPOSE_PROJECT_NAME" >&2
+  exit 32
+fi
+if [ "$A_PROJECT" = "$B_PROJECT" ]; then
+  echo "[smoke] FAIL: install #A and #B share COMPOSE_PROJECT_NAME (${A_PROJECT}) — T-0259 regression" >&2
+  exit 33
+fi
+echo "[smoke] install #B: project=${B_PROJECT} (distinct from #A: ${A_PROJECT})"
+
+# Stack A's containers must not have been recreated. Compare sorted IDs
+# before/after. Any mismatch means compose touched A's containers.
+cd "$REPO_DIR"
+A_IDS_AFTER="$(docker compose ps -q | sort | tr '\n' ' ')"
+if [ "$A_IDS_BEFORE" != "$A_IDS_AFTER" ]; then
+  echo "[smoke] FAIL: install #A's container IDs changed after install #B ran" >&2
+  echo "[smoke] before: ${A_IDS_BEFORE}" >&2
+  echo "[smoke] after:  ${A_IDS_AFTER}" >&2
+  exit 34
+fi
+echo "[smoke] install #A containers intact (IDs unchanged)"
+
+# Two distinct pgdata volumes must exist — one per project.
+if ! docker volume ls --format '{{.Name}}' | grep -q "^${A_PROJECT}_pgdata$"; then
+  echo "[smoke] FAIL: expected volume ${A_PROJECT}_pgdata in docker volume ls" >&2
+  docker volume ls --format '{{.Name}}' | grep -E '_pgdata$' >&2 || true
+  exit 35
+fi
+if ! docker volume ls --format '{{.Name}}' | grep -q "^${B_PROJECT}_pgdata$"; then
+  echo "[smoke] FAIL: expected volume ${B_PROJECT}_pgdata in docker volume ls" >&2
+  docker volume ls --format '{{.Name}}' | grep -E '_pgdata$' >&2 || true
+  exit 36
+fi
+
+echo "[smoke] non-collision scenario PASS (two independent stacks)"
 echo "[smoke] PASS (all scenarios)"

--- a/tests/test_installer.sh
+++ b/tests/test_installer.sh
@@ -10,13 +10,23 @@
 # SAFETY: this script tears the stack down (`docker compose down -v`) and
 # overwrites ./.env. It requires either TEST_INSTALLER_ALLOW_DESTROY=1 or
 # the `--allow-destroy` flag to guard against trashing a maintainer's local KB.
+#
+# Sprint 0044 T-0261: the installer no longer writes
+# `./brilliant-credentials.txt` on the default path — it auto-opens a
+# browser to `/setup` and the operator downloads the file from the
+# response page. The smoke test mirrors this by `curl -X POST`-ing
+# `/setup` itself and grepping the response HTML for the six expected
+# fields. The new fourth scenario (`headless-with-admin`) exercises the
+# `--admin-email` + `--admin-password` path, which DOES still produce
+# a credentials file (auto-written by the installer via `GET /credentials`
+# after admin bootstrap).
 
 set -euo pipefail
 
 MODE="--host"
 ALLOW_DESTROY="${TEST_INSTALLER_ALLOW_DESTROY:-0}"
-KEY_FILE="/tmp/brilliant-smoke-key.$$.txt"
 SUMMARY_FILE="/tmp/brilliant-smoke-summary.$$.txt"
+RESPONSE_FILE="/tmp/brilliant-smoke-response.$$.html"
 API_URL="http://localhost:8010"
 
 while [ $# -gt 0 ]; do
@@ -50,7 +60,7 @@ cleanup() {
   local rc=$?
   echo "[smoke] cleanup (rc=$rc)"
   docker compose down -v 2>/dev/null || true
-  rm -f "$KEY_FILE" "$SUMMARY_FILE" ./install.log ./brilliant-credentials.txt 2>/dev/null || true
+  rm -f "$SUMMARY_FILE" "$RESPONSE_FILE" ./install.log ./brilliant-credentials.txt 2>/dev/null || true
   return "$rc"
 }
 trap cleanup EXIT
@@ -65,11 +75,12 @@ rm -f ./.env
 
 START_TS=$(date +%s)
 
-echo "[smoke] running ./install.sh"
+echo "[smoke] running ./install.sh (default browser-ceremony path)"
+# Sprint 0044 T-0260/T-0261 — no --admin-email, no --key-out. The default
+# path stands the stack up and points the operator at /setup. The smoke
+# test drives the POST /setup ceremony itself below.
 ./install.sh \
-  --admin-email smoke@example.com \
   --force \
-  --key-out "$KEY_FILE" \
   | tee "$SUMMARY_FILE"
 
 END_TS=$(date +%s)
@@ -87,63 +98,41 @@ curl -fsS "${API_URL}/health" >/dev/null || {
   exit 11
 }
 
-echo "[smoke] asserting credentials file has all six keys"
-# Sprint 0043 T-0253 — brilliant-credentials.txt is now a key=value file
-# with six fields: admin_email, admin_api_key, oauth_client_id,
-# oauth_client_secret, mcp_url, login_url. Assert each key is present
-# with a non-empty value (oauth_client_secret is long hex; the grep
-# tolerates any non-empty value after the equals sign).
-for required_key in admin_email admin_api_key oauth_client_id oauth_client_secret mcp_url login_url; do
-  if ! grep -Eq "^${required_key}=.+" "$KEY_FILE"; then
-    echo "[smoke] FAIL: ${required_key} missing or empty in $KEY_FILE" >&2
-    echo "[smoke] credentials file contents:" >&2
-    cat "$KEY_FILE" >&2 || true
+echo "[smoke] POST /setup to claim admin and assert response body has all six fields"
+# Sprint 0044 T-0261 — replaces the old "grep KEY_FILE for six keys"
+# assertion. The /setup POST renders an HTML page containing the admin
+# API key (bkai_…), OAuth client id (brilliant_…), MCP URL (…/mcp), and
+# login URL (…/auth/login). We grep the response body for each marker.
+if ! curl -fsS -X POST "${API_URL}/setup" \
+    -d 'org_name=Smoke&email=smoke@example.com&password=TestPass123&password_confirm=TestPass123' \
+    -o "$RESPONSE_FILE"; then
+  echo "[smoke] FAIL: POST /setup did not succeed" >&2
+  exit 14
+fi
+
+for marker in 'bkai_' 'brilliant_' '/mcp' '/auth/login'; do
+  if ! grep -Fq "$marker" "$RESPONSE_FILE"; then
+    echo "[smoke] FAIL: /setup response missing marker '${marker}'" >&2
+    echo "[smoke] response body (first 50 lines):" >&2
+    head -n 50 "$RESPONSE_FILE" >&2 || true
     exit 14
   fi
 done
 
-echo "[smoke] asserting /entries with the admin key is 200"
-key="$(grep '^admin_api_key=' "$KEY_FILE" | head -n 1 | cut -d'=' -f2-)"
+echo "[smoke] extracting admin API key from /setup response for /entries check"
+# bkai_<24-hex-bytes> → 48 hex chars + possibly underscores in some shapes.
+# The grep is permissive on underscores so future key formats stay matched.
+key="$(grep -oE 'bkai_[a-f0-9_]+' "$RESPONSE_FILE" | head -1)"
 if [ -z "$key" ]; then
-  echo "[smoke] FAIL: admin_api_key value is empty" >&2
+  echo "[smoke] FAIL: could not extract bkai_ admin key from /setup response" >&2
   exit 15
 fi
+
+echo "[smoke] asserting /entries with the admin key is 200"
 code="$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer ${key}" "${API_URL}/entries")"
 if [ "$code" != "200" ]; then
   echo "[smoke] FAIL: /entries returned $code, expected 200" >&2
   exit 12
-fi
-
-echo "[smoke] asserting key file is mode 600"
-# Cross-platform mode check: GNU stat uses -c, BSD stat uses -f.
-mode="$(stat -c '%a' "$KEY_FILE" 2>/dev/null || stat -f '%Lp' "$KEY_FILE")"
-if [ "$mode" != "600" ]; then
-  echo "[smoke] FAIL: key file mode is $mode, expected 600" >&2
-  exit 13
-fi
-
-echo "[smoke] asserting banner's Key file path is absolute and resolvable from any CWD"
-# Extract the credentials-file path from the banner (captured in
-# $SUMMARY_FILE). The banner format is:
-#   Credentials file (contains 6 fields — keep it safe):
-#     <path> (mode 600)
-# So we match the header line, advance one line, and strip the "(mode 600)"
-# suffix + leading whitespace. Sprint 0043 T-0253 banner reshape.
-banner_key_path="$(awk '/Credentials file/ {getline; gsub(/^[[:space:]]+/, "", $0); sub(/ \(mode 600\).*$/, "", $0); print; exit}' "$SUMMARY_FILE")"
-if [ -z "$banner_key_path" ]; then
-  echo "[smoke] FAIL: could not extract Key file path from banner" >&2
-  echo "[smoke] banner contents:" >&2
-  cat "$SUMMARY_FILE" >&2 || true
-  exit 16
-fi
-case "$banner_key_path" in
-  /*) : ;;  # absolute — good
-  *)  echo "[smoke] FAIL: banner Key file path is relative ($banner_key_path)" >&2; exit 17 ;;
-esac
-# Resolve from a different CWD (as the operator would after the installer exits).
-if ! ( cd /tmp && test -r "$banner_key_path" ); then
-  echo "[smoke] FAIL: banner Key file path does not resolve from /tmp: $banner_key_path" >&2
-  exit 18
 fi
 
 echo "[smoke] baseline scenario PASS (${ELAPSED}s, under the 300s budget)"
@@ -153,7 +142,7 @@ echo "[smoke] baseline scenario PASS (${ELAPSED}s, under the 300s budget)"
 #
 # Goal: with host port 5442 already bound, the installer must probe and
 # pick the next +10 step (5452) for the DB, write BRILLIANT_DB_PORT to
-# `.env`, and surface the chosen value in the banner / credentials file.
+# `.env`, and surface the chosen value in the banner.
 #
 # Strategy:
 #   1. Tear down the baseline stack.
@@ -161,6 +150,9 @@ echo "[smoke] baseline scenario PASS (${ELAPSED}s, under the 300s budget)"
 #      small and trivially bindable; we trap-cleanup it no matter what).
 #   3. Re-run install.sh; expect BRILLIANT_DB_PORT=5452 in `.env`.
 #   4. Assert the chosen port flows into the banner's Postgres line.
+#   5. Lightweight `/setup` reachability check — the latch can only be
+#      claimed once per stack, and the baseline scenario already
+#      exercised the POST path.
 #
 # The API/MCP ports (8010/8011) are not artificially contended in this
 # test — if a stray dev server is bound to them on a maintainer machine
@@ -171,11 +163,10 @@ echo "[smoke] baseline scenario PASS (${ELAPSED}s, under the 300s budget)"
 echo "[smoke] port-conflict scenario: occupying 5442"
 
 CONFLICT_CONTAINER="bk-pg-conflict.$$"
-CONFLICT_KEY_FILE="/tmp/brilliant-smoke-conflict-key.$$.txt"
 CONFLICT_SUMMARY_FILE="/tmp/brilliant-smoke-conflict-summary.$$.txt"
 conflict_cleanup() {
   docker rm -f "$CONFLICT_CONTAINER" >/dev/null 2>&1 || true
-  rm -f "$CONFLICT_KEY_FILE" "$CONFLICT_SUMMARY_FILE" 2>/dev/null || true
+  rm -f "$CONFLICT_SUMMARY_FILE" 2>/dev/null || true
 }
 # Add to the main trap chain by layering a nested cleanup. bash `trap`
 # replaces rather than appends, so call both explicitly on EXIT.
@@ -207,9 +198,7 @@ fi
 
 echo "[smoke] running ./install.sh against contested :5442"
 ./install.sh \
-  --admin-email smoke-conflict@example.com \
   --force \
-  --key-out "$CONFLICT_KEY_FILE" \
   | tee "$CONFLICT_SUMMARY_FILE"
 
 echo "[smoke] asserting .env picked BRILLIANT_DB_PORT=5452"
@@ -228,17 +217,15 @@ if ! grep -Fq 'Postgres:     localhost:5452' "$CONFLICT_SUMMARY_FILE"; then
   exit 23
 fi
 
-echo "[smoke] asserting credentials file mentions the chosen ports"
-# mcp_url / login_url should still be present with non-empty values.
-# The exact ports depend on what else is bound on the machine; we just
-# assert the six-field contract still holds under conflict conditions.
-for required_key in admin_email admin_api_key oauth_client_id oauth_client_secret mcp_url login_url; do
-  if ! grep -Eq "^${required_key}=.+" "$CONFLICT_KEY_FILE"; then
-    echo "[smoke] FAIL: ${required_key} missing in conflict credentials file" >&2
-    cat "$CONFLICT_KEY_FILE" >&2 || true
-    exit 24
-  fi
-done
+echo "[smoke] asserting /setup is reachable on the conflict-shifted stack"
+# Sprint 0044 T-0261 — minimal reachability check; we don't POST here
+# because the baseline scenario already exercised /setup and the latch
+# can only be claimed once per stack. The conflict scenario's job is to
+# verify the port-probe behavior, not the ceremony.
+if ! curl -fsS "${API_URL}/setup" >/dev/null; then
+  echo "[smoke] FAIL: /setup not reachable on conflict-shifted stack" >&2
+  exit 24
+fi
 
 echo "[smoke] port-conflict scenario PASS"
 
@@ -281,7 +268,6 @@ echo "[smoke] install #A: project=${A_PROJECT} ids=${A_IDS_BEFORE}"
 
 ALT_ROOT="/tmp/bk-alt-$$"
 ALT_DIR="${ALT_ROOT}/xireactor-brilliant"
-ALT_KEY_FILE="/tmp/brilliant-smoke-alt-key.$$.txt"
 ALT_SUMMARY_FILE="/tmp/brilliant-smoke-alt-summary.$$.txt"
 
 noncollision_cleanup() {
@@ -290,7 +276,7 @@ noncollision_cleanup() {
     ( cd "$ALT_DIR" && docker compose down -v 2>/dev/null || true )
   fi
   rm -rf "$ALT_ROOT" 2>/dev/null || true
-  rm -f "$ALT_KEY_FILE" "$ALT_SUMMARY_FILE" 2>/dev/null || true
+  rm -f "$ALT_SUMMARY_FILE" 2>/dev/null || true
 }
 # Chain: non-collision cleanup → conflict cleanup → baseline cleanup.
 trap 'noncollision_cleanup; conflict_cleanup; cleanup' EXIT
@@ -313,9 +299,7 @@ cd "$ALT_DIR"
 
 echo "[smoke] running ./install.sh in ${ALT_DIR} (install #B)"
 ./install.sh \
-  --admin-email smoke-alt@example.com \
   --force \
-  --key-out "$ALT_KEY_FILE" \
   | tee "$ALT_SUMMARY_FILE"
 
 B_PROJECT="$(grep '^COMPOSE_PROJECT_NAME=' ./.env | head -n 1 | cut -d'=' -f2-)"
@@ -354,4 +338,91 @@ if ! docker volume ls --format '{{.Name}}' | grep -q "^${B_PROJECT}_pgdata$"; th
 fi
 
 echo "[smoke] non-collision scenario PASS (two independent stacks)"
+
+# ─────────────────────────────────────────────────────────────────────
+# Headless-with-admin scenario (Sprint 0044 T-0260/T-0261)
+#
+# Goal: when the operator passes --admin-email + --admin-password, the
+# installer:
+#   - writes ADMIN_EMAIL / ADMIN_PASSWORD / ADMIN_API_KEY to .env
+#   - bootstraps the admin user via env on API boot
+#   - skips the browser-open (--admin-email implies --headless)
+#   - after health-check, curls GET /credentials with the minted admin
+#     key and writes ./brilliant-credentials.txt (mode 600, six fields)
+#
+# This scenario covers the VPS / CI / scripted-install path that the user
+# will most likely automate against. We tear stack B and stack A down
+# first so the new install lands on a clean slate, then verify the
+# auto-written credentials file end-to-end.
+# ─────────────────────────────────────────────────────────────────────
+
+echo "[smoke] headless-with-admin scenario: tearing down prior stacks"
+# Stack B (alt dir).
+if [ -d "$ALT_DIR" ] && [ -f "$ALT_DIR/docker-compose.yml" ]; then
+  ( cd "$ALT_DIR" && docker compose down -v 2>/dev/null || true )
+fi
+# Stack A (this repo).
+docker compose down -v 2>/dev/null || true
+rm -f ./.env ./install.log ./brilliant-credentials.txt 2>/dev/null || true
+
+HEADLESS_SUMMARY_FILE="/tmp/brilliant-smoke-headless-summary.$$.txt"
+headless_cleanup() {
+  rm -f "$HEADLESS_SUMMARY_FILE" 2>/dev/null || true
+}
+# Chain: headless cleanup → non-collision cleanup → conflict cleanup → baseline cleanup.
+trap 'headless_cleanup; noncollision_cleanup; conflict_cleanup; cleanup' EXIT
+
+echo "[smoke] running ./install.sh --admin-email smoke@example.com --admin-password TestPass123"
+# Sprint 0044 T-0260 — --admin-email implies --headless, so no extra flag.
+# The installer writes the credentials file itself via curl /credentials.
+./install.sh \
+  --admin-email smoke@example.com \
+  --admin-password TestPass123 \
+  --force \
+  | tee "$HEADLESS_SUMMARY_FILE"
+
+echo "[smoke] asserting ./brilliant-credentials.txt was auto-written"
+if [ ! -f ./brilliant-credentials.txt ]; then
+  echo "[smoke] FAIL: ./brilliant-credentials.txt was not written by the installer" >&2
+  echo "[smoke] headless banner:" >&2
+  cat "$HEADLESS_SUMMARY_FILE" >&2 || true
+  exit 40
+fi
+
+echo "[smoke] asserting credentials file is mode 600"
+# Cross-platform mode check: GNU stat uses -c, BSD stat uses -f.
+mode="$(stat -c '%a' ./brilliant-credentials.txt 2>/dev/null || stat -f '%Lp' ./brilliant-credentials.txt)"
+if [ "$mode" != "600" ]; then
+  echo "[smoke] FAIL: credentials file mode is $mode, expected 600" >&2
+  exit 41
+fi
+
+echo "[smoke] asserting credentials file has all six key=value lines"
+for required_key in admin_email admin_api_key oauth_client_id oauth_client_secret mcp_url login_url; do
+  if ! grep -Eq "^${required_key}=.+" ./brilliant-credentials.txt; then
+    echo "[smoke] FAIL: ${required_key} missing or empty in ./brilliant-credentials.txt" >&2
+    echo "[smoke] credentials file contents:" >&2
+    cat ./brilliant-credentials.txt >&2 || true
+    exit 42
+  fi
+done
+
+echo "[smoke] extracting admin_api_key from credentials file for /entries check"
+headless_key="$(grep '^admin_api_key=' ./brilliant-credentials.txt | cut -d= -f2)"
+if [ -z "$headless_key" ]; then
+  echo "[smoke] FAIL: admin_api_key value is empty in credentials file" >&2
+  exit 43
+fi
+
+echo "[smoke] asserting /entries with the headless admin key is 200"
+headless_code="$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer ${headless_key}" "${API_URL}/entries")"
+if [ "$headless_code" != "200" ]; then
+  echo "[smoke] FAIL: /entries returned ${headless_code}, expected 200 (headless-with-admin)" >&2
+  exit 44
+fi
+
+echo "[smoke] tearing down headless-with-admin stack"
+docker compose down -v 2>/dev/null || true
+
+echo "[smoke] headless-with-admin scenario PASS"
 echo "[smoke] PASS (all scenarios)"

--- a/tests/test_installer.sh
+++ b/tests/test_installer.sh
@@ -273,6 +273,7 @@ ALT_SUMMARY_FILE="/tmp/brilliant-smoke-alt-summary.$$.txt"
 noncollision_cleanup() {
   # Tear down stack B from its own dir so its project (not A's) is targeted.
   if [ -d "$ALT_DIR" ] && [ -f "$ALT_DIR/docker-compose.yml" ]; then
+    # shellcheck disable=SC2015 # best-effort teardown; trailing `|| true` is intentional
     ( cd "$ALT_DIR" && docker compose down -v 2>/dev/null || true )
   fi
   rm -rf "$ALT_ROOT" 2>/dev/null || true
@@ -359,6 +360,7 @@ echo "[smoke] non-collision scenario PASS (two independent stacks)"
 echo "[smoke] headless-with-admin scenario: tearing down prior stacks"
 # Stack B (alt dir).
 if [ -d "$ALT_DIR" ] && [ -f "$ALT_DIR/docker-compose.yml" ]; then
+  # shellcheck disable=SC2015 # best-effort teardown; trailing `|| true` is intentional
   ( cd "$ALT_DIR" && docker compose down -v 2>/dev/null || true )
 fi
 # Stack A (this repo).

--- a/tests/test_installer.sh
+++ b/tests/test_installer.sh
@@ -87,8 +87,27 @@ curl -fsS "${API_URL}/health" >/dev/null || {
   exit 11
 }
 
+echo "[smoke] asserting credentials file has all six keys"
+# Sprint 0043 T-0253 — brilliant-credentials.txt is now a key=value file
+# with six fields: admin_email, admin_api_key, oauth_client_id,
+# oauth_client_secret, mcp_url, login_url. Assert each key is present
+# with a non-empty value (oauth_client_secret is long hex; the grep
+# tolerates any non-empty value after the equals sign).
+for required_key in admin_email admin_api_key oauth_client_id oauth_client_secret mcp_url login_url; do
+  if ! grep -Eq "^${required_key}=.+" "$KEY_FILE"; then
+    echo "[smoke] FAIL: ${required_key} missing or empty in $KEY_FILE" >&2
+    echo "[smoke] credentials file contents:" >&2
+    cat "$KEY_FILE" >&2 || true
+    exit 14
+  fi
+done
+
 echo "[smoke] asserting /entries with the admin key is 200"
-key="$(cat "$KEY_FILE")"
+key="$(grep '^admin_api_key=' "$KEY_FILE" | head -n 1 | cut -d'=' -f2-)"
+if [ -z "$key" ]; then
+  echo "[smoke] FAIL: admin_api_key value is empty" >&2
+  exit 15
+fi
 code="$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer ${key}" "${API_URL}/entries")"
 if [ "$code" != "200" ]; then
   echo "[smoke] FAIL: /entries returned $code, expected 200" >&2
@@ -103,11 +122,123 @@ if [ "$mode" != "600" ]; then
   exit 13
 fi
 
-echo "[smoke] asserting key file is one line"
-lines="$(wc -l <"$KEY_FILE")"
-if [ "$lines" -ne 1 ]; then
-  echo "[smoke] FAIL: key file has $lines lines, expected 1" >&2
-  exit 14
+echo "[smoke] asserting banner's Key file path is absolute and resolvable from any CWD"
+# Extract the credentials-file path from the banner (captured in
+# $SUMMARY_FILE). The banner format is:
+#   Credentials file (contains 6 fields — keep it safe):
+#     <path> (mode 600)
+# So we match the header line, advance one line, and strip the "(mode 600)"
+# suffix + leading whitespace. Sprint 0043 T-0253 banner reshape.
+banner_key_path="$(awk '/Credentials file/ {getline; gsub(/^[[:space:]]+/, "", $0); sub(/ \(mode 600\).*$/, "", $0); print; exit}' "$SUMMARY_FILE")"
+if [ -z "$banner_key_path" ]; then
+  echo "[smoke] FAIL: could not extract Key file path from banner" >&2
+  echo "[smoke] banner contents:" >&2
+  cat "$SUMMARY_FILE" >&2 || true
+  exit 16
+fi
+case "$banner_key_path" in
+  /*) : ;;  # absolute — good
+  *)  echo "[smoke] FAIL: banner Key file path is relative ($banner_key_path)" >&2; exit 17 ;;
+esac
+# Resolve from a different CWD (as the operator would after the installer exits).
+if ! ( cd /tmp && test -r "$banner_key_path" ); then
+  echo "[smoke] FAIL: banner Key file path does not resolve from /tmp: $banner_key_path" >&2
+  exit 18
 fi
 
-echo "[smoke] PASS (${ELAPSED}s, under the 300s budget)"
+echo "[smoke] baseline scenario PASS (${ELAPSED}s, under the 300s budget)"
+
+# ─────────────────────────────────────────────────────────────────────
+# Port-conflict scenario (Sprint 0043 T-0257)
+#
+# Goal: with host port 5442 already bound, the installer must probe and
+# pick the next +10 step (5452) for the DB, write BRILLIANT_DB_PORT to
+# `.env`, and surface the chosen value in the banner / credentials file.
+#
+# Strategy:
+#   1. Tear down the baseline stack.
+#   2. Occupy 5442 with a disposable container (postgres:16-alpine is
+#      small and trivially bindable; we trap-cleanup it no matter what).
+#   3. Re-run install.sh; expect BRILLIANT_DB_PORT=5452 in `.env`.
+#   4. Assert the chosen port flows into the banner's Postgres line.
+#
+# The API/MCP ports (8010/8011) are not artificially contended in this
+# test — if a stray dev server is bound to them on a maintainer machine
+# that's fine, the probe will just shift the api/mcp ports too and the
+# banner will reflect whatever it picked.
+# ─────────────────────────────────────────────────────────────────────
+
+echo "[smoke] port-conflict scenario: occupying 5442"
+
+CONFLICT_CONTAINER="bk-pg-conflict.$$"
+CONFLICT_KEY_FILE="/tmp/brilliant-smoke-conflict-key.$$.txt"
+CONFLICT_SUMMARY_FILE="/tmp/brilliant-smoke-conflict-summary.$$.txt"
+conflict_cleanup() {
+  docker rm -f "$CONFLICT_CONTAINER" >/dev/null 2>&1 || true
+  rm -f "$CONFLICT_KEY_FILE" "$CONFLICT_SUMMARY_FILE" 2>/dev/null || true
+}
+# Add to the main trap chain by layering a nested cleanup. bash `trap`
+# replaces rather than appends, so call both explicitly on EXIT.
+trap 'conflict_cleanup; cleanup' EXIT
+
+echo "[smoke] tearing down baseline stack before conflict probe"
+docker compose down -v 2>/dev/null || true
+rm -f ./.env ./install.log ./brilliant-credentials.txt 2>/dev/null || true
+
+echo "[smoke] starting sentinel container on host port 5442"
+if ! docker run --rm -d \
+    -p 5442:5432 \
+    -e POSTGRES_PASSWORD=conflict \
+    --name "$CONFLICT_CONTAINER" \
+    postgres:16-alpine >/dev/null; then
+  echo "[smoke] FAIL: could not start sentinel postgres container on :5442" >&2
+  exit 20
+fi
+# Give Docker a moment to actually bind the port before the probe runs.
+sleep 2
+
+# Sanity-check that the port really is occupied from the probe's POV.
+if command -v lsof >/dev/null 2>&1; then
+  if ! lsof -i :5442 -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "[smoke] FAIL: sentinel container did not bind 5442 (lsof view)" >&2
+    exit 21
+  fi
+fi
+
+echo "[smoke] running ./install.sh against contested :5442"
+./install.sh \
+  --admin-email smoke-conflict@example.com \
+  --force \
+  --key-out "$CONFLICT_KEY_FILE" \
+  | tee "$CONFLICT_SUMMARY_FILE"
+
+echo "[smoke] asserting .env picked BRILLIANT_DB_PORT=5452"
+if ! grep -Eq '^BRILLIANT_DB_PORT=5452$' ./.env; then
+  echo "[smoke] FAIL: expected BRILLIANT_DB_PORT=5452 in .env" >&2
+  echo "[smoke] .env port lines:" >&2
+  grep -E '^BRILLIANT_(DB|API|MCP)_PORT=' ./.env >&2 || true
+  exit 22
+fi
+
+echo "[smoke] asserting banner's Postgres line reports the chosen 5452 port"
+if ! grep -Fq 'Postgres:     localhost:5452' "$CONFLICT_SUMMARY_FILE"; then
+  echo "[smoke] FAIL: banner did not report localhost:5452" >&2
+  echo "[smoke] conflict banner:" >&2
+  cat "$CONFLICT_SUMMARY_FILE" >&2 || true
+  exit 23
+fi
+
+echo "[smoke] asserting credentials file mentions the chosen ports"
+# mcp_url / login_url should still be present with non-empty values.
+# The exact ports depend on what else is bound on the machine; we just
+# assert the six-field contract still holds under conflict conditions.
+for required_key in admin_email admin_api_key oauth_client_id oauth_client_secret mcp_url login_url; do
+  if ! grep -Eq "^${required_key}=.+" "$CONFLICT_KEY_FILE"; then
+    echo "[smoke] FAIL: ${required_key} missing in conflict credentials file" >&2
+    cat "$CONFLICT_KEY_FILE" >&2 || true
+    exit 24
+  fi
+done
+
+echo "[smoke] port-conflict scenario PASS"
+echo "[smoke] PASS (all scenarios)"

--- a/tests/test_installer.sh
+++ b/tests/test_installer.sh
@@ -188,12 +188,28 @@ fi
 # Give Docker a moment to actually bind the port before the probe runs.
 sleep 2
 
-# Sanity-check that the port really is occupied from the probe's POV.
-if command -v lsof >/dev/null 2>&1; then
-  if ! lsof -i :5442 -sTCP:LISTEN >/dev/null 2>&1; then
-    echo "[smoke] FAIL: sentinel container did not bind 5442 (lsof view)" >&2
-    exit 21
+# Sanity-check that the port really is occupied from the installer's POV.
+# Use a TCP connect rather than `lsof -sTCP:LISTEN`: on Linux Docker
+# Engine setups without docker-proxy, the forwarded port is only a DNAT
+# rule and has no listening socket. A connect attempt (what nc -z does,
+# and what install.sh's port_in_use now checks) always succeeds when the
+# container is accepting forwarded traffic.
+port_bound=0
+for _ in 1 2 3 4 5; do
+  if command -v nc >/dev/null 2>&1 && nc -z localhost 5442 >/dev/null 2>&1; then
+    port_bound=1
+    break
   fi
+  if (exec 3<>/dev/tcp/127.0.0.1/5442) 2>/dev/null; then
+    exec 3<&- 3>&-
+    port_bound=1
+    break
+  fi
+  sleep 1
+done
+if [ "$port_bound" -eq 0 ]; then
+  echo "[smoke] FAIL: sentinel container did not bind 5442 (tcp connect)" >&2
+  exit 21
 fi
 
 echo "[smoke] running ./install.sh against contested :5442"

--- a/tests/test_setup_banner.py
+++ b/tests/test_setup_banner.py
@@ -16,6 +16,9 @@ plus the DB-reading helper (``_services_ready``) with a minimal async
 pool stub. A full wire-through-the-POST-handler test would flip the
 ``first_run_complete`` latch, poisoning the rest of the suite — and the
 unit tests here cover the same invariant without that side effect.
+
+Spec 0043 / T-0255 extends these tests with brand-header + pulsing-CTA
++ beforeunload + import-vault-fragment assertions.
 """
 
 from __future__ import annotations
@@ -32,7 +35,12 @@ _API_DIR = _REPO_ROOT / "api"
 if str(_API_DIR) not in sys.path:
     sys.path.insert(0, str(_API_DIR))
 
-from routes.setup import _render_done_page, _services_ready  # noqa: E402
+from routes.setup import (  # noqa: E402
+    _render_brand_header,
+    _render_done_page,
+    _render_setup_form,
+    _services_ready,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -183,3 +191,123 @@ def test_services_ready_false_on_db_error():
     # Fail-closed: any exception → show the banner (treat as "not ready")
     # rather than silently suppress it.
     assert _run(_services_ready(_BrokenPool())) is False
+
+
+# ---------------------------------------------------------------------------
+# Spec 0043 / T-0255 — brand header + pulsing CTA + beforeunload guard +
+# import-vault fragment link
+# ---------------------------------------------------------------------------
+
+
+def test_brand_header_renders_logo_title_and_tagline():
+    """The shared brand header renders the Brilliant mark + tagline.
+
+    The tagline copy must match the README hero ("One shared knowledge
+    base for your whole AI-enabled team") so first-run operators see
+    identical messaging across the landing page and the installer path.
+    """
+    header = _render_brand_header()
+
+    assert 'class="brand-header"' in header
+    # Logo SVG (gem-shape polygon + "Brilliant logo" aria label)
+    assert "Brilliant logo" in header
+    # Title SVG (xiReactor / Brilliant wordmark)
+    assert "xiReactor / Brilliant" in header
+    # Tagline must match the README hero copy verbatim.
+    assert (
+        "One shared knowledge base for your whole AI-enabled team"
+        in header
+    )
+
+
+def test_setup_form_includes_brand_header():
+    """The pre-claim /setup form also surfaces the brand mark."""
+    body = _render_setup_form()
+    assert 'class="brand-header"' in body
+    assert "Brilliant logo" in body
+    assert "One shared knowledge base for your whole AI-enabled team" in body
+
+
+def test_done_page_includes_brand_header_and_pulsing_cta():
+    """Credentials page must render brand + pulsing download CTA."""
+    body = _call_render(services_ready=True)
+
+    # Brand header assertions — same expectations as the shared helper.
+    assert 'class="brand-header"' in body
+    assert "Brilliant logo" in body
+    assert "xiReactor / Brilliant" in body
+    assert "One shared knowledge base for your whole AI-enabled team" in body
+
+    # Download CTA has the pulse class + matching keyframes + JS to
+    # clear the pulse on first click.
+    assert 'id="download"' in body
+    assert 'class="pulse"' in body
+    assert "@keyframes brilliant-pulse" in body
+    # Pulse clears via classList.remove on first click / ack.
+    assert 'classList.remove("pulse")' in body
+
+
+def test_done_page_beforeunload_guard_wired():
+    """beforeunload listener + its two clearing paths must be present."""
+    body = _call_render(services_ready=True)
+
+    # The listener itself.
+    assert "beforeunload" in body
+    assert "ev.preventDefault()" in body
+    # Two legitimate ways out: download click + saved-ack checkbox.
+    assert 'id="saved-ack-checkbox"' in body
+    assert "I've saved my credentials" in body
+    assert "clearGuard()" in body
+    # Dismiss sentinel persists to localStorage so the next page visit
+    # doesn't re-arm the pulse.
+    assert "brilliant_creds_downloaded" in body
+
+
+def test_done_page_import_vault_fragment_link():
+    """The Import Obsidian vault button carries #api_key=<key> + target=_blank.
+
+    The URL fragment is the handoff channel between /setup and
+    /import/vault — it never hits the server because fragments stay
+    client-side. The link must also open in a new tab so the operator's
+    current tab keeps showing the one-shot credentials.
+    """
+    body = _render_done_page(
+        email="admin@example.com",
+        api_key="bkai_plain_xyz_1234567890",
+        client_id="client-demo",
+        client_secret="secret-demo",
+        mcp_url="https://example.test/mcp",
+        login_url="https://example.test/auth/login",
+        services_ready=True,
+    )
+
+    # Fragment-carrying link present with the exact plaintext key.
+    assert "/import/vault#api_key=bkai_plain_xyz_1234567890" in body
+    # Opens in a new tab with rel=noopener to protect the credentials tab.
+    assert 'target="_blank"' in body
+    assert 'rel="noopener"' in body
+    # Label text cues the operator to what they're about to do.
+    assert "Import Obsidian vault" in body
+
+
+def test_done_page_html_escapes_api_key_in_fragment_href():
+    """API keys are alphanumeric in practice, but we still pass them
+    through html.escape to guard against a surprise URL-unfriendly
+    character ever reaching the href attribute. Confirm the helper is
+    in the chain by asserting the rendered href uses the escaped form.
+    """
+    # "<" in a key would explode the attribute if we didn't escape; this
+    # is a belt-and-braces check that the html.escape call is wired in.
+    body = _render_done_page(
+        email="admin@example.com",
+        api_key='abc"def<xyz',
+        client_id="cid",
+        client_secret="csecret",
+        mcp_url="https://example.test/mcp",
+        login_url="https://example.test/auth/login",
+        services_ready=True,
+    )
+    # Escaped attribute-safe form of the key must appear in the href.
+    assert "abc&quot;def&lt;xyz" in body
+    # The raw-unescaped combination must never appear inside an href="…".
+    assert 'href="/import/vault#api_key=abc"def<xyz"' not in body

--- a/tools/remove_demo_data.py
+++ b/tools/remove_demo_data.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Remove demo seed data from a Brilliant Postgres instance.
+
+What this tool does
+-------------------
+Deletes every row planted by ``db/seed/demo.sql``:
+
+* Entries carrying the ``demo:seed`` tag (FK-cascades cover
+  ``entry_links`` + ``entry_versions``).
+* Staging / audit / project_assignments / api_keys rows owned by the
+  seed users (``usr_admin``, ``usr_editor``, ``usr_commenter``,
+  ``usr_viewer``).
+* The four demo user rows themselves.
+
+Real (non-demo) entries and the admin-bootstrap'd user are untouched:
+the bootstrap path creates a user with a UUID id (``crypto.randbytes``
+based) and the real admin's entries do NOT carry the ``demo:seed`` tag.
+The ``org_demo`` organization row is intentionally preserved because
+admin_bootstrap reuses it for the real admin.
+
+Why the sentinel is a tag, not a column
+---------------------------------------
+``entries.source`` is CHECK-constrained to ``('web_ui', 'agent', 'api')``
+by ``db/migrations/001_core.sql``; we cannot add ``'demo'`` without a
+schema change. The ``tags`` column is ``TEXT[]`` with no CHECK, so a
+``'demo:seed'`` marker drops in cleanly and is trivially ``ANY()``-able.
+
+Idempotency
+-----------
+Safe to re-run. A clean DB (no demo rows) exits 0 after reporting
+``0`` deletions across every category. Re-running after a partial
+failure completes the remaining deletions; tuples already gone produce
+``0`` row counts and are not errors.
+
+Usage
+-----
+    DATABASE_URL=postgresql://... python tools/remove_demo_data.py --yes
+
+    # Interactive (prompts for confirmation):
+    DATABASE_URL=postgresql://... python tools/remove_demo_data.py
+
+Exit codes
+----------
+    0  — completed (possibly a no-op on a clean DB)
+    1  — DATABASE_URL missing or connection failed
+    2  — aborted by user at interactive confirmation prompt
+    3  — SQL error during deletion
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import psycopg
+
+
+# Demo user IDs are stable across seed runs — see db/seed/demo.sql.
+# The admin-bootstrap flow (api/admin_bootstrap.py) creates a user with
+# a UUID id, so these literal ids never collide with real users.
+DEMO_USER_IDS = ("usr_admin", "usr_editor", "usr_commenter", "usr_viewer")
+
+# Tag sentinel on every seeded entry row — see db/seed/demo.sql.
+DEMO_ENTRY_TAG = "demo:seed"
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Remove Brilliant demo seed data (idempotent).",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help=(
+            "Skip the interactive confirmation prompt. Required for "
+            "non-interactive cleanups (CI, scripts, one-shot wipes)."
+        ),
+    )
+    parser.add_argument(
+        "--database-url",
+        default=None,
+        help="Postgres DSN (overrides DATABASE_URL env var).",
+    )
+    return parser.parse_args(argv)
+
+
+def _confirm_interactive() -> bool:
+    """Prompt on stdin; require an explicit 'yes' to proceed."""
+    print(
+        "About to delete demo seed rows (entries tagged 'demo:seed' "
+        "plus users usr_admin/usr_editor/usr_commenter/usr_viewer and "
+        "all rows owned by them). Real entries and the admin-bootstrap "
+        "user are unaffected.",
+        file=sys.stderr,
+    )
+    try:
+        answer = input("Type 'yes' to continue: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print("\nAborted (no tty).", file=sys.stderr)
+        return False
+    return answer == "yes"
+
+
+def _count_demo_rows(cur: psycopg.Cursor) -> dict[str, int]:
+    """Snapshot current counts for reporting before + after deletion."""
+    counts: dict[str, int] = {}
+
+    cur.execute(
+        "SELECT count(*) FROM entries WHERE %s = ANY(tags)",
+        (DEMO_ENTRY_TAG,),
+    )
+    counts["entries"] = cur.fetchone()[0]
+
+    cur.execute(
+        "SELECT count(*) FROM users WHERE id = ANY(%s)",
+        (list(DEMO_USER_IDS),),
+    )
+    counts["users"] = cur.fetchone()[0]
+
+    cur.execute(
+        "SELECT count(*) FROM api_keys WHERE user_id = ANY(%s)",
+        (list(DEMO_USER_IDS),),
+    )
+    counts["api_keys"] = cur.fetchone()[0]
+
+    cur.execute(
+        "SELECT count(*) FROM staging WHERE submitted_by = ANY(%s)",
+        (list(DEMO_USER_IDS),),
+    )
+    counts["staging"] = cur.fetchone()[0]
+
+    cur.execute(
+        "SELECT count(*) FROM audit_log WHERE actor_id = ANY(%s)",
+        (list(DEMO_USER_IDS),),
+    )
+    counts["audit_log"] = cur.fetchone()[0]
+
+    cur.execute(
+        "SELECT count(*) FROM project_assignments WHERE user_id = ANY(%s)",
+        (list(DEMO_USER_IDS),),
+    )
+    counts["project_assignments"] = cur.fetchone()[0]
+
+    return counts
+
+
+def _delete_demo_rows(cur: psycopg.Cursor) -> dict[str, int]:
+    """Delete demo rows in FK-dependency order. Returns deleted rowcounts."""
+    deleted: dict[str, int] = {}
+
+    # 1) Entries (ON DELETE CASCADE covers entry_links + entry_versions).
+    cur.execute(
+        "DELETE FROM entries WHERE %s = ANY(tags)",
+        (DEMO_ENTRY_TAG,),
+    )
+    deleted["entries"] = cur.rowcount
+
+    # 2) Project assignments referencing demo users (no cascade from users).
+    cur.execute(
+        "DELETE FROM project_assignments WHERE user_id = ANY(%s) "
+        "OR assigned_by = ANY(%s)",
+        (list(DEMO_USER_IDS), list(DEMO_USER_IDS)),
+    )
+    deleted["project_assignments"] = cur.rowcount
+
+    # 3) Staging rows submitted or reviewed by demo users.
+    cur.execute(
+        "DELETE FROM staging WHERE submitted_by = ANY(%s) "
+        "OR reviewed_by = ANY(%s)",
+        (list(DEMO_USER_IDS), list(DEMO_USER_IDS)),
+    )
+    deleted["staging"] = cur.rowcount
+
+    # 4) Audit-log rows actor'd by demo users.
+    cur.execute(
+        "DELETE FROM audit_log WHERE actor_id = ANY(%s)",
+        (list(DEMO_USER_IDS),),
+    )
+    deleted["audit_log"] = cur.rowcount
+
+    # 5) API keys for demo users.
+    cur.execute(
+        "DELETE FROM api_keys WHERE user_id = ANY(%s)",
+        (list(DEMO_USER_IDS),),
+    )
+    deleted["api_keys"] = cur.rowcount
+
+    # 6) Demo user rows.
+    cur.execute(
+        "DELETE FROM users WHERE id = ANY(%s)",
+        (list(DEMO_USER_IDS),),
+    )
+    deleted["users"] = cur.rowcount
+
+    # Intentionally NOT deleting `organizations` row `org_demo` — admin_bootstrap
+    # reuses it for the real admin. If no real admin has been bootstrapped and
+    # the caller wants a truly clean DB, they can drop+recreate the schema.
+
+    return deleted
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+
+    dsn = args.database_url or os.environ.get("DATABASE_URL")
+    if not dsn:
+        print(
+            "ERROR: DATABASE_URL is not set and --database-url was not passed.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not args.yes:
+        if not _confirm_interactive():
+            return 2
+
+    try:
+        conn = psycopg.connect(dsn)
+    except psycopg.Error as exc:
+        print(f"ERROR: could not connect to Postgres: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                before = _count_demo_rows(cur)
+                if sum(before.values()) == 0:
+                    print(
+                        "No demo rows found — nothing to delete. "
+                        "(Idempotent no-op; safe to re-run.)"
+                    )
+                    return 0
+
+                print("Demo rows found:")
+                for table, n in before.items():
+                    print(f"  {table:>22}: {n}")
+
+                deleted = _delete_demo_rows(cur)
+
+                print("\nDeleted:")
+                for table, n in deleted.items():
+                    print(f"  {table:>22}: {n}")
+    except psycopg.Error as exc:
+        print(f"ERROR: SQL failure during delete: {exc}", file=sys.stderr)
+        return 3
+    finally:
+        conn.close()
+
+    print("\nDone. Demo rows removed. Real entries and the admin-bootstrap "
+          "user are unaffected.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/render_migrate.py
+++ b/tools/render_migrate.py
@@ -59,12 +59,18 @@ MIGRATIONS_DIR = Path(__file__).resolve().parent.parent / "db" / "migrations"
 INITDB_SNAPSHOT_MAX_NUMBER = 26
 
 # Migrations that exist for local demo/dogfood only and must NOT run on a
-# production Render deploy. Reasons per file:
+# production Render deploy. Retained for historical Render DBs where
+# 005_seed.sql was previously skipped and recorded in schema_migrations:
+# the file has since moved to db/seed/demo.sql (opt-in via
+# `install.sh --seed-demo`) but we keep the name in SKIP_ON_RENDER so a
+# future cross-reference to the schema_migrations row still resolves.
+# Render v0.5.1+ installs will simply never see the file in MIGRATIONS_DIR.
+#
+# Historical reason (still true for any DB pre-v0.5.1):
 #   - 005_seed.sql — inserts demo users with publicly-known plaintext API
 #     keys and demo entries. Would be a security hole on a real deploy,
 #     and also fails under FORCE ROW LEVEL SECURITY because Render's
-#     auto-generated DB user is not a superuser. The /setup admin claim
-#     ceremony creates the real admin; production starts empty.
+#     auto-generated DB user is not a superuser.
 # Listed files are still recorded in schema_migrations so the tool treats
 # them as "applied" and doesn't retry them every deploy.
 SKIP_ON_RENDER = {"005_seed.sql"}


### PR DESCRIPTION
## Summary

- **Sprint 0043** (installer-fix, #40–#45): credentials recovery, `/setup` polish, seed opt-in, port probing, parameterized compose project/container/volume names
- **Sprint 0044** (#46/#47): unify installer + Render on a single `/setup` web ceremony — kill env-bootstrap default, add `--headless`, interactive password prompt, browser auto-open
- **ST-0206/0207/0208 bundle**: thread `BRILLIANT_{MCP,API}_{PUBLIC_URL,PORT}` + `OAUTH_HANDOFF_SECRET` through installer + compose; RFC 6749 §2.3.1 `_BasicAuthTokenBodyBridge` ASGI middleware in `mcp/remote_server.py` so Claude Desktop `mcp-remote` can auth against FastMCP `/token`
- **T-0267** (#47): one-token fix for `/append` 500 — `governance_action="appended"` → `"updated"` (CHECK constraint violation)
- **CI-unblock fixes** (ST-0217, added post-open): `014dcb0` silences two SC2015 infos on intentional best-effort teardown lines; `19c2577` fixes a shipped-but-latent installer bug — `install.sh::port_in_use` and the smoke port-conflict sanity check both treated `lsof -sTCP:LISTEN` as authoritative, which misses Docker ports forwarded via pure DNAT on Linux Engine setups with `userland-proxy=false` (GitHub Actions runners hit this). Now either `lsof` or `nc -z` / TCP-connect reporting "occupied" wins.

Render lane validated end-to-end (video-ready). Installer lane scenario 1 passed after `871c9f6`; scenarios 2–5 deferred with known gaps catalogued in spec `0045` (T-0264 umbrella) for a follow-up v0.5.1.x / v0.5.2.

## Test plan

- [x] Render wet-test green (ST-0213)
- [x] Installer scenario 1 green post-`871c9f6` (ST-0213)
- [x] `tests/test_basic_auth_bridge.py` — 12 scenarios pass in mcp container (T-0263)
- [x] Static lints: `shellcheck install.sh` + `shellcheck tests/test_installer.sh`, `bash -n`, pytest collectible
- [x] CI smoke + smoke-self-clone green (run 24783016129)
- [ ] Installer scenarios 2–5 — deferred (known T-0264 gaps, non-blocking for Render-first release)
- [ ] `/append` on Render post-merge — confirm no 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)