### PR TITLE
Sprint 0046: vault import MOC wikilink + type fixes (T-0272)

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -6,20 +6,10 @@ from typing import Literal, Optional
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
-# Valid content types matching the DB CHECK constraint
-VALID_CONTENT_TYPES = {
-    "context",
-    "project",
-    "meeting",
-    "decision",
-    "intelligence",
-    "daily",
-    "resource",
-    "department",
-    "team",
-    "system",
-    "onboarding",
-}
+# NOTE: content_type is governed by `content_type_registry` at runtime
+# (migration 016 dropped the CHECK constraint on entries.content_type).
+# Unknown types are auto-registered as `is_active=false` by the import
+# path — see `api/routes/import_files.py::_resolve_content_type`.
 
 VALID_SENSITIVITIES = {
     "system",
@@ -287,6 +277,10 @@ class ImportSummary(BaseModel):
     errors: list[str]
     type_mappings: dict[str, str] = {}
     unrecognized_types: list[str] = []
+    # Number of distinct wikilink / internal-markdown targets the link
+    # resolver couldn't match (T-0272.3). Sample is capped client-side.
+    unresolved_links: int = 0
+    unresolved_links_sample: list[str] = []
 
 
 VALID_COLLISION_TYPES = {"path", "title", "content_hash"}
@@ -375,6 +369,12 @@ class ImportExecuteResponse(BaseModel):
     # so operators can reproduce / roll back from the stored bytes. Other
     # import paths leave this as ``None``.
     blob_id: str | None = None
+    # Count + sample of wikilink / internal-markdown targets the link resolver
+    # couldn't match (T-0272.3). Surfaces silent-unresolved bugs loudly in the
+    # import response instead of hiding them in server logs. Sample truncated
+    # server-side (currently 20 targets) — full set remains in INFO logs.
+    unresolved_links: int = 0
+    unresolved_links_sample: list[str] = []
 
 
 class RollbackResponse(BaseModel):

--- a/api/routes/import_files.py
+++ b/api/routes/import_files.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import tarfile
 import zipfile
 
@@ -22,6 +23,7 @@ from services.frontmatter import (
     parse_frontmatter,
 )
 from services import audit
+from services.audit import _app_role_to_pg_role
 from services.links import sync_entry_links
 from services.storage import get_storage
 from services.vault_walker import iter_archive_md, resolve_exclude_patterns
@@ -46,7 +48,7 @@ router = APIRouter(tags=["import"])
 # Regex to detect [[wiki-links]] in markdown content.
 # Captures up to the first | (display text) or # (heading anchor) or ]],
 # handling [[Note]], [[Note|display]], and [[Note#Heading]] formats.
-_WIKI_LINK_RE = re.compile(r"\[\[([^\]|#]+)")
+_WIKI_LINK_RE = re.compile(r"\[\[([^\]|#\\]+)")
 
 # Regex for inline #tags in content (but not ## headings)
 _INLINE_TAG_RE = re.compile(r"(?:^|\s)#([a-zA-Z][\w-]*)", re.MULTILINE)
@@ -272,11 +274,27 @@ async def detect_collisions(
     return collisions
 
 
-async def _resolve_content_type(conn, meta: dict, filename: str, logical_path: str):
+async def _resolve_content_type(
+    conn,
+    meta: dict,
+    filename: str,
+    logical_path: str,
+    user: UserContext,
+):
     """Resolve content_type from frontmatter, registry, daily note pattern, or path inference.
 
     Returns (content_type, type_mapping_or_None, unrecognized_type_or_None).
     Accepts both `content_type` (preferred, #25) and the legacy `type` alias.
+
+    When frontmatter declares a type that is not in
+    `content_type_registry`, the type is auto-registered with
+    `is_active=false` inside a privilege-scoped savepoint
+    (`SET LOCAL ROLE kb_admin`) mirroring `api/services/audit.py::record`.
+    The declared type is then used verbatim on the entry — the registry
+    change is runtime-only (no migration) and admins promote the row via
+    an explicit `UPDATE ... SET is_active=true` grant. The raw type is
+    still returned in the `unrecognized_type` slot so callers can surface
+    it in `unrecognized_types` for admin review (spec 0046 / T-0272.2).
     """
     raw_type = meta.get("content_type", "") or meta.get("type", "")
     if isinstance(raw_type, list):
@@ -292,8 +310,55 @@ async def _resolve_content_type(conn, meta: dict, filename: str, logical_path: s
         if reg_row:
             canonical = reg_row[1] if reg_row[1] else reg_row[0]
             return canonical, (raw_type, canonical), None
-        else:
-            return infer_content_type(logical_path), None, raw_type
+
+        # Auto-register the unknown type as is_active=false. RLS grants
+        # INSERT on `content_type_registry` to `kb_admin` only, so we
+        # briefly elevate inside a SAVEPOINT and restore the caller's
+        # role before RELEASE — identical pattern to audit.record.
+        sp_name = f"sp_autoreg_{secrets.token_hex(6)}"
+        pg_role = _app_role_to_pg_role(user.role, user.source)
+        try:
+            await conn.execute(f"SAVEPOINT {sp_name}")
+            try:
+                await conn.execute("SET LOCAL ROLE kb_admin")
+                await conn.execute(
+                    """
+                    INSERT INTO content_type_registry (name, description, is_active)
+                    VALUES (%s, 'Auto-registered from vault import — promote via admin', false)
+                    ON CONFLICT (name) DO NOTHING
+                    """,
+                    (raw_type,),
+                )
+            finally:
+                # Restore caller's role before RELEASE so the outer
+                # transaction continues under the original role.
+                try:
+                    await conn.execute(f"SET LOCAL ROLE {pg_role}")
+                except Exception:  # pragma: no cover — defensive
+                    logger.exception(
+                        "_resolve_content_type: failed to restore role to %s",
+                        pg_role,
+                    )
+            await conn.execute(f"RELEASE SAVEPOINT {sp_name}")
+        except Exception:
+            # Don't block the import — log + rollback the savepoint so the
+            # outer transaction remains valid. The declared type is still
+            # used on the entry; only the registry side-effect is lost.
+            logger.exception(
+                "_resolve_content_type: auto-register failed for %r — continuing",
+                raw_type,
+            )
+            try:
+                await conn.execute(f"ROLLBACK TO SAVEPOINT {sp_name}")
+                await conn.execute(f"RELEASE SAVEPOINT {sp_name}")
+            except Exception:  # pragma: no cover — defensive
+                logger.exception(
+                    "_resolve_content_type: failed to rollback savepoint %s",
+                    sp_name,
+                )
+
+        # Use the declared type verbatim; still flag via unrecognized_types.
+        return raw_type, None, raw_type
     elif _DAILY_NOTE_RE.match(filename):
         return "daily", None, None
     else:
@@ -338,7 +403,7 @@ async def import_preview(
         for fd in parsed_files:
             try:
                 content_type, mapping, unrec = await _resolve_content_type(
-                    conn, fd["meta"], fd["filename"], fd["logical_path"]
+                    conn, fd["meta"], fd["filename"], fd["logical_path"], user
                 )
                 fd["content_type"] = content_type
                 if mapping:
@@ -431,6 +496,10 @@ async def _execute_import(
     errors: list[str] = []
     type_mappings: dict[str, str] = {}
     unrecognized_types: set[str] = set()
+    # Aggregate unresolved wikilink / internal-markdown targets across every
+    # file so the HTTP response can surface them (see T-0272.3). Set-dedup
+    # means a target referenced from many MOCs counts once.
+    all_unresolved: set[str] = set()
 
     # Whether this user goes through staging
     use_staging = user.role in ("commenter", "viewer") or user.key_type == "agent"
@@ -517,18 +586,20 @@ async def _execute_import(
                 created += 1  # count as processed
                 continue
 
-            # Resolve content_type (frontmatter governance wins over
-            # registry/inference when it already validated).
-            if "content_type" in governance:
-                content_type = governance["content_type"]
-            else:
-                content_type, mapping, unrec = await _resolve_content_type(
-                    conn, meta, file.filename, logical_path
-                )
-                if mapping:
-                    type_mappings[mapping[0]] = mapping[1]
-                if unrec:
-                    unrecognized_types.add(unrec)
+            # Resolve content_type unconditionally. `_resolve_content_type`
+            # handles the full spectrum: registry hit (known type, no side
+            # effect), registry miss with frontmatter-declared type
+            # (auto-register `is_active=false` + flag as unrecognized), and
+            # frontmatter-silent (fall back to path inference). Short-circuiting
+            # on `governance["content_type"]` skips the auto-register side
+            # effect and breaks `moc` round-tripping (spec 0046 AC #3).
+            content_type, mapping, unrec = await _resolve_content_type(
+                conn, meta, file.filename, logical_path, user
+            )
+            if mapping:
+                type_mappings[mapping[0]] = mapping[1]
+            if unrec:
+                unrecognized_types.add(unrec)
 
             # Sensitivity / department / summary come from frontmatter
             # when provided; otherwise fall back to existing defaults.
@@ -640,7 +711,7 @@ async def _execute_import(
     # INSERTs so cross-file references within this batch resolve correctly.
     for source_id, content in pending_links:
         try:
-            linked += await sync_entry_links(
+            batch_linked, batch_unresolved = await sync_entry_links(
                 conn,
                 source_id,
                 content,
@@ -649,6 +720,8 @@ async def _execute_import(
                 user.source,
                 import_batch_id=batch_id,
             )
+            linked += batch_linked
+            all_unresolved.update(batch_unresolved)
         except Exception as exc:
             errors.append(f"link {source_id}: {str(exc)}")
 
@@ -680,6 +753,10 @@ async def _execute_import(
         unrecognized_types=sorted(unrecognized_types),
         batch_id=batch_id,
         collisions_resolved=collisions_resolved,
+        unresolved_links=len(all_unresolved),
+        # Truncate the sample to 20 — a 1000-target list over HTTP is noisy
+        # and the per-entry INFO log keeps the full set available for ops.
+        unresolved_links_sample=sorted(all_unresolved)[:20],
     )
 
 

--- a/api/services/frontmatter.py
+++ b/api/services/frontmatter.py
@@ -39,21 +39,10 @@ VALID_SENSITIVITIES: frozenset = frozenset(
         "shared",
     }
 )
-VALID_CONTENT_TYPES: frozenset = frozenset(
-    {
-        "context",
-        "project",
-        "meeting",
-        "decision",
-        "intelligence",
-        "daily",
-        "resource",
-        "department",
-        "team",
-        "system",
-        "onboarding",
-    }
-)
+# NOTE: content_type is NOT whitelisted here. `content_type_registry` is the
+# sole authority (migration 016 dropped the CHECK constraint on
+# `entries.content_type`). Unknown types are auto-registered at import time
+# as `is_active=false` by `_resolve_content_type` in routes/import_files.py.
 
 
 # Frontmatter keys that map to first-class `entries` columns. Everything else
@@ -171,9 +160,11 @@ def extract_governance_fields(meta: dict) -> dict:
 
     Returns a dict with any of `sensitivity`, `content_type`, `department`,
     `summary` (each only present when the frontmatter supplied a usable
-    value). Values are validated against `VALID_SENSITIVITIES` /
-    `VALID_CONTENT_TYPES`; invalid values are dropped so the caller falls
-    back to the existing inference path.
+    value). `sensitivity` is still validated against `VALID_SENSITIVITIES`;
+    `content_type` passes through any non-empty string — the
+    `content_type_registry` table is the sole authority, and unknown types
+    are auto-registered downstream in `_resolve_content_type` (spec 0046 /
+    T-0272.2).
     """
     out: dict = {}
 
@@ -187,7 +178,7 @@ def extract_governance_fields(meta: dict) -> dict:
         ct_raw = meta.get("type")
     if isinstance(ct_raw, list):
         ct_raw = ct_raw[0] if ct_raw else None
-    if isinstance(ct_raw, str) and ct_raw.strip() in VALID_CONTENT_TYPES:
+    if isinstance(ct_raw, str) and ct_raw.strip():
         out["content_type"] = ct_raw.strip()
 
     dept = meta.get("department")

--- a/api/services/links.py
+++ b/api/services/links.py
@@ -27,7 +27,7 @@ import re
 
 logger = logging.getLogger(__name__)
 
-_WIKI_LINK_RE = re.compile(r"\[\[([^\]|#]+)")
+_WIKI_LINK_RE = re.compile(r"\[\[([^\]|#\\]+)")
 # Capture the character preceding the `[` so we can reject image syntax
 # (`![alt](src)`). Group 1 is the leading char (or empty at string start),
 # group 2 is the link label, group 3 is the target.
@@ -62,12 +62,21 @@ async def sync_entry_links(
     user_id: str,
     source: str,
     import_batch_id: str | None = None,
-) -> int:
+) -> tuple[int, list[str]]:
     """Delete existing entry_links for `entry_id` then re-insert from `content`.
 
-    Returns the number of link rows written. Unresolved targets are skipped
-    silently (the read-time resolver will pass them through as literal text).
-    Idempotent: safe to call repeatedly with the same content.
+    Returns ``(linked, unresolved)`` — the number of link rows written and the
+    list of wikilink / internal-markdown targets the org-scoped DB lookup
+    didn't match. Unresolved targets are skipped silently at link-insert time
+    (the read-time resolver will pass them through as literal text), but we
+    return them so callers (notably the import pipeline) can surface the miss
+    in their HTTP response. Idempotent: safe to call repeatedly with the same
+    content.
+
+    The returned ``unresolved`` list is untrimmed — callers decide how many
+    samples to keep. A per-entry INFO log still fires at call time so
+    per-entry granularity is available for debugging even when the caller
+    discards the tuple.
 
     Operates on the caller's connection so it participates in the caller's
     transaction — partial failures roll back with the parent write.
@@ -82,7 +91,7 @@ async def sync_entry_links(
 
     # Cheap sniff: bail only when neither reference form can possibly match.
     if not content or ("[[" not in content and "](" not in content):
-        return 0
+        return 0, []
 
     wiki_targets = _WIKI_LINK_RE.findall(content)
     md_targets = [
@@ -91,7 +100,7 @@ async def sync_entry_links(
         if _is_internal_md_target(target)
     ]
     if not wiki_targets and not md_targets:
-        return 0
+        return 0, []
 
     # Dedup across both forms while preserving order. Wiki links scan first
     # (historical order) so a target referenced both ways resolves once.
@@ -165,4 +174,4 @@ async def sync_entry_links(
             ", ".join(unresolved[:10]),
         )
 
-    return linked
+    return linked, unresolved

--- a/api/services/render.py
+++ b/api/services/render.py
@@ -8,9 +8,14 @@ resolver. See spec 0028.
 
 import re
 
-# Matches [[slug]] or [[slug|alias]]. The slug capture excludes ']' and '|'
-# so nested brackets / pipes stay unmatched and pass through unchanged.
-_WIKI_LINK_RE = re.compile(r"\[\[([^\]|]+?)(?:\|([^\]]+))?\]\]")
+# Matches [[slug]] or [[slug|alias]], including the Obsidian table-cell
+# escape form `[[slug\|alias]]` (a literal `\` is required inside table
+# cells to avoid the cell delimiter eating the alias pipe). The slug
+# stop class adds `\\` so `target-a\` doesn't bleed into the slug
+# capture; the optional `\\?` after the slug consumes the escape so the
+# alternation `(?:\|...)` can still match the alias pipe. Stop class
+# also excludes `]` and `|` so nested brackets / pipes pass through.
+_WIKI_LINK_RE = re.compile(r"\[\[([^\]|\\]+?)\\?(?:\|([^\]]+))?\]\]")
 
 
 async def resolve_wiki_links(content: str, conn, source_entry_id: str) -> str:

--- a/tests/fixtures/vault/moc-entries.md
+++ b/tests/fixtures/vault/moc-entries.md
@@ -1,0 +1,11 @@
+---
+title: Entries Index
+type: moc
+summary: Table of contents for top-level notes.
+---
+# Entries Index
+
+| Entry | Description |
+| --- | --- |
+| [[target-a\|Alpha]] | First top-level note. |
+| [[target-b\|Beta]] | Second top-level note. |

--- a/tests/fixtures/vault/target-a.md
+++ b/tests/fixtures/vault/target-a.md
@@ -1,0 +1,6 @@
+---
+title: Alpha
+---
+# Alpha
+
+First top-level note referenced from the MOC index.

--- a/tests/fixtures/vault/target-b.md
+++ b/tests/fixtures/vault/target-b.md
@@ -1,0 +1,6 @@
+---
+title: Beta
+---
+# Beta
+
+Second top-level note referenced from the MOC index.

--- a/tests/test_entries_render.py
+++ b/tests/test_entries_render.py
@@ -292,3 +292,98 @@ def test_no_wiki_token_short_circuits_db_query():
     assert conn.calls == [], (
         f"resolver must not issue a DB query when '[[' is absent; got {conn.calls!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Wiki-link regex captures Obsidian table-cell escape shape
+# `[[slug\|alias]]` cleanly (sprint 0046 / Bug A render-side regression).
+#
+# Pure unit test against the compiled regex. No DB, no API.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(False, reason="pure unit test; always runs")
+def test_wiki_link_regex_captures_table_escape_form():
+    import sys
+    import pathlib
+
+    api_dir = pathlib.Path(__file__).resolve().parents[1] / "api"
+    if str(api_dir) not in sys.path:
+        sys.path.insert(0, str(api_dir))
+
+    from services.render import _WIKI_LINK_RE  # type: ignore
+
+    cases = [
+        # (input, expected slug, expected alias)
+        ("[[target-a\\|Alpha]]", "target-a", "Alpha"),  # table-cell escape
+        ("[[target-a|Alpha]]", "target-a", "Alpha"),     # plain pipe
+        ("[[target-a]]", "target-a", None),               # no alias
+        ("[[a\\|b]]", "a", "b"),                          # single-char escape
+    ]
+    for content, want_slug, want_alias in cases:
+        m = _WIKI_LINK_RE.search(content)
+        assert m is not None, f"regex failed to match {content!r}"
+        assert m.group(1) == want_slug, (
+            f"slug mismatch for {content!r}: got {m.group(1)!r}, want {want_slug!r}"
+        )
+        assert m.group(2) == want_alias, (
+            f"alias mismatch for {content!r}: got {m.group(2)!r}, want {want_alias!r}"
+        )
+
+    # Mixed line — make sure findall returns both matches with correct shapes.
+    matches = _WIKI_LINK_RE.findall(
+        "See [[target-a\\|Alpha]] and [[target-b]] for context."
+    )
+    assert matches == [("target-a", "Alpha"), ("target-b", "")], (
+        f"mixed-line findall mismatch: {matches!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: resolve_wiki_links rewrites table-escape `[[slug\|alias]]` to
+# `[alias](/kb/<id>)` end-to-end against a fake conn (no API, no DB).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(False, reason="pure unit test; always runs")
+def test_resolve_wiki_links_rewrites_table_escape():
+    import sys
+    import pathlib
+
+    api_dir = pathlib.Path(__file__).resolve().parents[1] / "api"
+    if str(api_dir) not in sys.path:
+        sys.path.insert(0, str(api_dir))
+
+    from services.render import resolve_wiki_links  # type: ignore
+
+    target_id_a = "11111111-1111-1111-1111-111111111111"
+    target_id_b = "22222222-2222-2222-2222-222222222222"
+
+    class _StubConn:
+        async def execute(self, sql, params=None):
+            class _Cur:
+                async def fetchall(self_inner):
+                    return [
+                        (target_id_a, "Alpha Title", "target-a"),
+                        (target_id_b, "Beta Title", "target-b"),
+                    ]
+            return _Cur()
+
+    content = (
+        "| Entry | Notes |\n"
+        "|-------|-------|\n"
+        "| [[target-a\\|Alpha]] | [[target-b]] |\n"
+    )
+    out = asyncio.run(
+        resolve_wiki_links(content, _StubConn(), "00000000-0000-0000-0000-000000000000")
+    )
+    assert f"[Alpha](/kb/{target_id_a})" in out, (
+        f"table-escape alias did not resolve: {out!r}"
+    )
+    assert f"[Beta Title](/kb/{target_id_b})" in out, (
+        f"plain `[[target-b]]` did not resolve: {out!r}"
+    )
+    # And the literal `[[target-a\|Alpha]]` form must be gone.
+    assert "[[target-a\\|" not in out, (
+        f"literal table-escape leaked through: {out!r}"
+    )

--- a/tests/test_import_frontmatter.py
+++ b/tests/test_import_frontmatter.py
@@ -137,9 +137,25 @@ def test_extract_governance_fields_rejects_unknown_sensitivity():
     assert "sensitivity" not in gov  # not in VALID_SENSITIVITIES
 
 
-def test_extract_governance_fields_rejects_unknown_content_type():
+def test_extract_governance_fields_accepts_unknown_content_type():
+    """`content_type_registry` is the sole authority (spec 0046 / T-0272.2).
+
+    Unknown values are no longer dropped at parse time — they pass through
+    so `_resolve_content_type` can auto-register them as `is_active=false`
+    in the registry table.
+    """
     gov = extract_governance_fields({"content_type": "invented"})
-    assert "content_type" not in gov
+    assert gov["content_type"] == "invented"
+
+
+def test_extract_governance_fields_accepts_moc():
+    """`type: moc` is the motivating case for spec 0046 — a MOC (Map of
+    Content) hub note. It must round-trip unchanged through
+    `extract_governance_fields` so the subsequent registry lookup can
+    auto-register it.
+    """
+    gov = extract_governance_fields({"content_type": "moc"})
+    assert gov["content_type"] == "moc"
 
 
 def test_extract_governance_fields_content_type_alias_accepted():
@@ -183,7 +199,7 @@ def test_build_domain_meta_strips_known_keys_keeps_unknown():
 
 import re  # noqa: E402
 
-_WIKI_LINK_RE = re.compile(r"\[\[([^\]|#]+)")
+_WIKI_LINK_RE = re.compile(r"\[\[([^\]|#\\]+)")
 
 
 @pytest.mark.parametrize(
@@ -194,6 +210,9 @@ _WIKI_LINK_RE = re.compile(r"\[\[([^\]|#]+)")
         ("Pipe display: [[Alpha|the alpha project]].", ["Alpha"]),
         ("Heading anchor: [[Alpha#Section]].", ["Alpha"]),
         ("No wikilinks here.", []),
+        ("Table: [[ent-0567\\|display]]", ["ent-0567"]),
+        ("Mixed: [[Alpha]] and [[ent-0567\\|x]]", ["Alpha", "ent-0567"]),
+        ("Trailing backslash no pipe: [[ent-0567\\]]", ["ent-0567"]),
     ],
 )
 def test_wiki_link_regex(content, expected):

--- a/tools/backfill_entry_links.py
+++ b/tools/backfill_entry_links.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""
+Backfill entry_links for import batches affected by the Bug A regex gap.
+
+Re-runs sync_entry_links across every entry in one (or all) import_batches
+for a given org. Needed for prod recovery of MOC table-escaped wikilinks
+(spec 0046, T-0272.4) that were silently unresolved before the regex fix
+in T-0272.1 landed.
+
+Usage:
+    # Dry-run a specific batch
+    python tools/backfill_entry_links.py \\
+        --dsn "$DATABASE_URL" \\
+        --org-id "$ORG_ID" \\
+        --batch-id 3b1de26f-e923-46a7-8d77-2f8007f141b7 \\
+        --dry-run
+
+    # Real run, all batches for org
+    python tools/backfill_entry_links.py \\
+        --dsn "$DATABASE_URL" \\
+        --org-id "$ORG_ID"
+
+Prerequisites:
+- T-0272.1 regex fix must be deployed (running against old regex reproduces Bug A).
+- DB role must be superuser or kb_admin; script SET LOCAL ROLEs kb_admin.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+
+import psycopg
+
+# Make `api.services.links` importable when invoked from repo root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from api.services.links import sync_entry_links  # noqa: E402
+
+logger = logging.getLogger("backfill_entry_links")
+
+# Mirror api/database.py's sanitizer so SET LOCAL interpolation is safe.
+_SAFE_VALUE = re.compile(r"^[\w\-\.]+$")
+
+
+def _sanitize(value: str, *, label: str) -> str:
+    val = str(value)
+    if not _SAFE_VALUE.match(val):
+        raise ValueError(f"Unsafe value for {label}: {val!r}")
+    return val
+
+
+def _truncate(s: str, n: int = 80) -> str:
+    s = s or ""
+    return s if len(s) <= n else s[: n - 3] + "..."
+
+
+async def _list_batches(conn, org_id: str, batch_id: str | None) -> list[dict]:
+    """Return batch rows for processing, newest first when scanning all."""
+    if batch_id:
+        sql = (
+            "SELECT id::text, created_by, linked_count, source_vault, created_at "
+            "FROM import_batches "
+            "WHERE org_id = %s AND id = %s::uuid"
+        )
+        cur = await conn.execute(sql, (org_id, batch_id))
+    else:
+        sql = (
+            "SELECT id::text, created_by, linked_count, source_vault, created_at "
+            "FROM import_batches "
+            "WHERE org_id = %s "
+            "ORDER BY created_at DESC"
+        )
+        cur = await conn.execute(sql, (org_id,))
+
+    rows = await cur.fetchall()
+    return [
+        {
+            "id": r[0],
+            "created_by": r[1],
+            "linked_count": r[2],
+            "source_vault": r[3],
+            "created_at": r[4],
+        }
+        for r in rows
+    ]
+
+
+async def _count_existing_links(conn, batch_id: str) -> int:
+    """Count current entry_links rows whose source entry belongs to batch_id.
+
+    We count rows attributable to the batch via the source entry (rather than
+    entry_links.import_batch_id directly) so the metric tracks the total
+    outgoing edges currently on the batch's entries, which is what
+    import_batches.linked_count semantically represents.
+    """
+    cur = await conn.execute(
+        """
+        SELECT COUNT(*)
+          FROM entry_links el
+          JOIN entries e ON e.id = el.source_entry_id
+         WHERE e.import_batch_id = %s::uuid
+        """,
+        (batch_id,),
+    )
+    row = await cur.fetchone()
+    return int(row[0]) if row else 0
+
+
+async def _process_batch(
+    conn,
+    org_id: str,
+    batch: dict,
+    dry_run: bool,
+) -> dict:
+    """Process a single batch; returns a stats dict for reporting.
+
+    Uses one transaction for the batch. In dry-run mode the transaction is
+    rolled back at the end so no writes persist.
+    """
+    batch_id = batch["id"]
+    created_by = batch["created_by"]
+
+    # Manually manage the transaction so we can ROLLBACK on dry-run.
+    await conn.execute("BEGIN")
+    try:
+        # Session scoping for RLS + role elevation. SET LOCAL dies with the tx.
+        await conn.execute(f"SET LOCAL app.org_id = '{_sanitize(org_id, label='org_id')}'")
+        await conn.execute(f"SET LOCAL app.user_id = '{_sanitize(created_by, label='created_by')}'")
+        await conn.execute("SET LOCAL app.role = 'admin'")
+        await conn.execute("SET LOCAL app.department = ''")
+        await conn.execute("SET LOCAL ROLE kb_admin")
+
+        before_linked = await _count_existing_links(conn, batch_id)
+
+        # Pull every published entry in this batch.
+        cur = await conn.execute(
+            """
+            SELECT id::text, content, created_by
+              FROM entries
+             WHERE import_batch_id = %s::uuid
+               AND status = 'published'
+             ORDER BY created_at
+            """,
+            (batch_id,),
+        )
+        entries = await cur.fetchall()
+
+        total_linked = 0
+        unresolved_union: list[str] = []
+        unresolved_seen: set[str] = set()
+
+        for row in entries:
+            entry_id, content, entry_created_by = row[0], row[1], row[2]
+            # Prefer the entry's own created_by for audit provenance; fall
+            # back to batch.created_by if for some reason it's null.
+            user_id = entry_created_by or created_by
+            linked, unresolved = await sync_entry_links(
+                conn,
+                entry_id,
+                content or "",
+                org_id,
+                user_id,
+                source="api",
+                import_batch_id=batch_id,
+            )
+            total_linked += linked
+            for t in unresolved:
+                key = t.lower()
+                if key not in unresolved_seen:
+                    unresolved_seen.add(key)
+                    unresolved_union.append(t)
+
+        after_linked = await _count_existing_links(conn, batch_id)
+
+        # Keep import_batches.linked_count in sync with the new edge total
+        # so /import/batches reports the recovered number. Skip in dry-run.
+        if not dry_run:
+            await conn.execute(
+                "UPDATE import_batches SET linked_count = %s WHERE id = %s::uuid",
+                (after_linked, batch_id),
+            )
+            await conn.execute("COMMIT")
+        else:
+            await conn.execute("ROLLBACK")
+
+        return {
+            "batch_id": batch_id,
+            "source_vault": batch["source_vault"],
+            "entries": len(entries),
+            "before_linked": before_linked,
+            "after_linked": after_linked,
+            "delta": after_linked - before_linked,
+            "total_linked_written": total_linked,
+            "unresolved_sample": unresolved_union[:5],
+            "unresolved_total": len(unresolved_union),
+            "dry_run": dry_run,
+        }
+    except Exception:
+        # Make sure we don't leak an open tx on error.
+        try:
+            await conn.execute("ROLLBACK")
+        except Exception:  # noqa: BLE001
+            pass
+        raise
+
+
+def _print_report(stats: dict) -> None:
+    """Print a single-line summary for a batch."""
+    sample = " | ".join(_truncate(t) for t in stats["unresolved_sample"])
+    mode = "DRY-RUN" if stats["dry_run"] else "APPLIED"
+    logger.info(
+        "%s batch=%s vault=%s entries=%d before_linked=%d after_linked=%d "
+        "delta=%d unresolved_total=%d unresolved_sample=[%s]",
+        mode,
+        stats["batch_id"],
+        stats["source_vault"],
+        stats["entries"],
+        stats["before_linked"],
+        stats["after_linked"],
+        stats["delta"],
+        stats["unresolved_total"],
+        sample,
+    )
+
+
+async def _run(dsn: str, org_id: str, batch_id: str | None, dry_run: bool) -> int:
+    async with await psycopg.AsyncConnection.connect(dsn, autocommit=True) as conn:
+        # Initialize session-level app.* GUCs so RLS policies resolve during
+        # the pre-transaction _list_batches() SELECT. Render Postgres does
+        # not have these GUCs pre-registered at the cluster level, so an
+        # unset current_setting('app.org_id') raises UndefinedObject.
+        safe_org = _sanitize(org_id, label="org_id")
+        await conn.execute(f"SET app.org_id = '{safe_org}'")
+        await conn.execute("SET app.user_id = ''")
+        await conn.execute("SET app.role = 'admin'")
+        await conn.execute("SET app.department = ''")
+
+        batches = await _list_batches(conn, org_id, batch_id)
+        if not batches:
+            if batch_id:
+                logger.error(
+                    "No import_batches row found for org_id=%s batch_id=%s",
+                    org_id,
+                    batch_id,
+                )
+            else:
+                logger.error("No import_batches rows found for org_id=%s", org_id)
+            return 1
+
+        logger.info(
+            "Processing %d batch(es) for org_id=%s (dry_run=%s)",
+            len(batches),
+            org_id,
+            dry_run,
+        )
+
+        totals = {"entries": 0, "delta": 0, "unresolved_total": 0}
+        for batch in batches:
+            stats = await _process_batch(conn, org_id, batch, dry_run)
+            _print_report(stats)
+            totals["entries"] += stats["entries"]
+            totals["delta"] += stats["delta"]
+            totals["unresolved_total"] += stats["unresolved_total"]
+
+        logger.info(
+            "TOTAL batches=%d entries=%d delta=%d unresolved_total=%d (dry_run=%s)",
+            len(batches),
+            totals["entries"],
+            totals["delta"],
+            totals["unresolved_total"],
+            dry_run,
+        )
+    return 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Backfill entry_links across import batches (spec 0046, T-0272.4).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  # Dry-run a single prod batch:
+  python tools/backfill_entry_links.py \\
+      --dsn "$DATABASE_URL" --org-id "$ORG_ID" \\
+      --batch-id 3b1de26f-e923-46a7-8d77-2f8007f141b7 --dry-run
+
+  # Apply to every batch in the org, newest first:
+  python tools/backfill_entry_links.py --org-id "$ORG_ID"
+""",
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.environ.get("DATABASE_URL"),
+        help="Postgres DSN (default: $DATABASE_URL).",
+    )
+    parser.add_argument(
+        "--org-id",
+        required=True,
+        help="Tenant org_id to scope the backfill (required even as superuser).",
+    )
+    parser.add_argument(
+        "--batch-id",
+        default=None,
+        help="Specific import_batches.id (UUID). If omitted, scan all batches "
+        "for the org in created_at DESC order.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Count would-be-recovered edges without writing; rolls back each "
+        "per-batch transaction.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable DEBUG-level logging.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    if not args.dsn:
+        print(
+            "ERROR: --dsn not provided and DATABASE_URL not set. "
+            "Pass --dsn or export DATABASE_URL.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        _sanitize(args.org_id, label="org_id")
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        return asyncio.run(_run(args.dsn, args.org_id, args.batch_id, args.dry_run))
+    except psycopg.Error as exc:
+        logger.error("Database error: %s", exc)
+        return 1
+    except KeyboardInterrupt:
+        logger.error("Interrupted")
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Unhandled error: %s", exc)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes three vault-import bugs surfaced during graph-viz of the dogfood vault (ST-0223):

- **Bug A — Wikilink regex.** `_WIKI_LINK_RE` stop class missed `\\`, so the Obsidian table-cell escape form `[[slug\|alias]]` silently captured `slug\` and never resolved against `entries.logical_path`. Fixed in three sites (`api/services/links.py`, `api/routes/import_files.py`, test mirror) plus the read-time renderer (`api/services/render.py`, T-0272.6).
- **Bug B — `type:` whitelist.** `VALID_CONTENT_TYPES` frozenset in `api/services/frontmatter.py` collapsed any non-whitelisted frontmatter value (`type: moc`, etc.) to `context`. Removed; `_resolve_content_type` now auto-registers unknown values into `content_type_registry` (`is_active=false`) under a scoped `SET LOCAL ROLE kb_admin` on import. No DB migration.
- **Bug C — Observability.** `sync_entry_links` now returns `tuple[int, list[str]]`; import path accumulates `all_unresolved` and surfaces `unresolved_links` + `unresolved_links_sample` on `ImportExecuteResponse` / `ImportSummary` (pydantic defaults preserve backward-compat).

Adds `tools/backfill_entry_links.py` for tenant-scoped recovery of batches imported before the fix deployed.

## Prod recovery (already applied)

Ran the backfill on Render org_demo / batch `3b1de26f-…` 2026-04-24T15:17 EDT after a clean dry-run with identical numbers:

| Metric | Before | After |
|---|---|---|
| `import_batches.linked_count` | 1242 | **2512** (+1270) |
| Entries Index `bf0555cc-…` outgoing edges | 0 | **844** |
| Unresolved tokens | n/a | 3 genuine orphans (`That`, `Where`, `prj-slug`) |

Frontend graph viz visually confirmed by Jeremy. Bug-B footprint on this batch was zero (no `type: moc` in source vault); Bug A was the entire prod impact.

## Files changed

- `api/services/links.py` — regex fix; `sync_entry_links` returns `(linked, unresolved)`.
- `api/routes/import_files.py` — regex fix; `_resolve_content_type` auto-registers unknowns; `_execute_import` accumulates unresolved set; surfaces fields on response.
- `api/services/frontmatter.py` — `VALID_CONTENT_TYPES` deleted; `extract_governance_fields` pass-throughs any non-empty string.
- `api/services/render.py` — read-time regex sibling fix (`\\` stop class + `\\?` consume between slug and alias).
- `api/models.py` — `ImportExecuteResponse` + `ImportSummary` add `unresolved_links: int = 0` + `unresolved_links_sample: list[str] = []`.
- `tools/backfill_entry_links.py` — new; argparse CLI; per-batch `BEGIN/SET LOCAL/COMMIT-or-ROLLBACK`; reuses prod `sync_entry_links`. Two latent bugs surfaced + patched mid-rehearsal: `source="api"` (CHECK-constraint violation under `"backfill"`), and session-level `SET app.*` before pre-tx `_list_batches` (Render Postgres has no pre-registered `app.*` GUCs).
- `tests/test_import_frontmatter.py` — regex mirror updated; 3 new parametrize cases (table-escape, mixed, trailing-backslash); `accepts_unknown_content_type` flip; new `accepts_moc` case.
- `tests/test_entries_render.py` — 2 new pure-unit tests for the render-side regex (table-escape capture + end-to-end stub-conn rewrite).
- `tests/fixtures/vault/moc-entries.md` + `target-a.md` + `target-b.md` — permanent regression-guard fixture.

## Test plan

- [x] Unit-scope pytest: 41 passed / 49 skipped (regex 8/8, governance 5/5, render-side 3/3, plus existing imports/credentials/oauth/storage/observability/pdf/attachments/service-role/basic-auth/vault-walker).
- [x] Spec-validation grep block: regex-identity (3/3 sites), no-`VALID_CONTENT_TYPES`, `sync_entry_links(` call-sites consistent (4 prod + 1 backfill).
- [x] Local wet-test: `POST /import/vault-from-blob` of MOC fixture returns `linked: 2, unresolved_links: 0, unrecognized_types: ["moc"]`; DB shows hub `content_type='moc'`, registry auto-register row, 2 `entry_links`.
- [x] Local backfill dry-run: batch `fcecb94a-…` delta=+1270, idempotent, ROLLBACK clean.
- [x] Prod dry-run: batch `3b1de26f-…` delta=+1270 (exact local parity), no writes.
- [x] Prod real run: applied; DB probe verified `linked_count=2512`, batch-scoped `entry_links` count=2512, Entries Index out-degree=844.
- [x] Frontend graph viz: visually confirmed.
- [ ] Pre-existing live-API tests in `test_entries_render.py` (Tests 1–3) and 21 fail/64 err integration tests still need a live `docker compose up` stack on `localhost:8010`; environmental gap, not in scope for this PR.

## Refs

- Spec: `.xireactor/specs/0046--2026-04-24--vault-import-wikilink-and-moc-fixes.md`
- Tasks: T-0272.1 (regex), .2 (whitelist drop + auto-register), .3 (observability), .4 (backfill script), .5 (wet-test), .6 (render-side regex fold-in)
- Diagnosis: ST-0223 / CL-0189
- Recovery: ST-0226 / CL-0192 / CL-0194 / CL-0195
- Memory lessons added: `feedback_render_pg_app_gucs_unregistered.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)