### PR TITLE
Sprint 0047: 3D KB preview Easter egg + Render Blueprint deploy hardening

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,4 +5,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY api/ ./
 COPY tools/ ./tools/
 COPY db/migrations/ ./db/migrations/
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/main.py
+++ b/api/main.py
@@ -4,7 +4,7 @@ import logging
 import os
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 
@@ -110,6 +110,19 @@ app.add_middleware(RequestLogMiddleware)
 async def health():
     """Health check endpoint."""
     return {"status": "ok"}
+
+
+@app.head("/")
+async def root_head():
+    """Lightweight HEAD / for Render's edge health probe.
+
+    Render's port-detection probe hits HEAD / repeatedly during the
+    "service is live → port detected" handoff. Without this handler,
+    FastAPI returns 405 Method Not Allowed and Render's edge can take
+    minutes to finalize routing (5min gap observed on 2026-04-28 deploy).
+    Mirrors the fix already applied to the MCP service (commit 5772ea3).
+    """
+    return Response(status_code=200)
 
 
 @app.get("/")

--- a/api/main.py
+++ b/api/main.py
@@ -85,10 +85,13 @@ def _log_ready_banner() -> None:
     public_url = os.environ.get("RENDER_EXTERNAL_URL", "").strip()
     setup_url = f"{public_url}/setup" if public_url else "http://localhost:8010/setup"
     bar = "=" * 64
-    logger.info(bar)
-    logger.info("  YOUR BRILLIANT SYSTEM IS COMPLETELY READY NOW")
-    logger.info("  Open: %s", setup_url)
-    logger.info(bar)
+    # WARNING level (not INFO) so the banner survives the default
+    # logger threshold — `brilliant.api` has no handler/level config,
+    # so info() falls through Python's lastResort and gets dropped.
+    logger.warning(bar)
+    logger.warning("  YOUR BRILLIANT SYSTEM IS COMPLETELY READY NOW")
+    logger.warning("  Open: %s", setup_url)
+    logger.warning(bar)
 
 
 @asynccontextmanager

--- a/api/main.py
+++ b/api/main.py
@@ -73,12 +73,31 @@ async def _publish_public_url_to_db(pool) -> None:
         )
 
 
+def _log_ready_banner() -> None:
+    """Emit an unmistakable "ready" marker for operators watching Render logs.
+
+    A fresh Render deploy can take ~3-4 min from "deploy started" to "edge
+    routing live". Without an explicit marker, a non-technical operator
+    watching the log stream has no signal for when it's safe to click the
+    setup link. This banner is the signal: when this line scrolls past,
+    open the URL.
+    """
+    public_url = os.environ.get("RENDER_EXTERNAL_URL", "").strip()
+    setup_url = f"{public_url}/setup" if public_url else "http://localhost:8010/setup"
+    bar = "=" * 64
+    logger.info(bar)
+    logger.info("  YOUR BRILLIANT SYSTEM IS COMPLETELY READY NOW")
+    logger.info("  Open: %s", setup_url)
+    logger.info(bar)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage connection pool lifecycle and run startup bootstrap."""
     await init_pool()
     await _publish_public_url_to_db(get_pool())
     await ensure_admin_user(get_pool())
+    _log_ready_banner()
     yield
     await close_pool()
 

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -75,6 +75,17 @@ def _render_login_form(email: str = "", error: str | None = None) -> str:
   button {{ padding: 10px 14px; font-size: 1rem; background: #111; color: #fff;
             border: 0; border-radius: 6px; cursor: pointer; }}
   button:hover {{ background: #333; }}
+  button:disabled, button[aria-busy="true"] {{
+    opacity: 0.75; cursor: wait; background: #333;
+  }}
+  button[aria-busy="true"]::after {{
+    content: ""; display: inline-block; width: 10px; height: 10px;
+    margin-left: 8px; vertical-align: -1px;
+    border: 2px solid rgba(255,255,255,0.4);
+    border-top-color: #fff; border-radius: 50%;
+    animation: brilliant-spin 0.7s linear infinite;
+  }}
+  @keyframes brilliant-spin {{ to {{ transform: rotate(360deg); }} }}
   .error {{ background: #fdecec; color: #8a1f1f; padding: 10px 12px;
             border-radius: 6px; border: 1px solid #f5b5b5; }}
   .warn {{ background: #fff8e1; border: 1px solid #f0d878; color: #6b5200;
@@ -100,6 +111,23 @@ def _render_login_form(email: str = "", error: str | None = None) -> str:
     </label>
     <button type="submit">Sign in &amp; rotate key</button>
   </form>
+  <script>
+    (function () {{
+      var form = document.querySelector('form[action="/auth/login"]');
+      if (!form) return;
+      form.addEventListener('submit', function (e) {{
+        var btn = form.querySelector('button[type=submit]');
+        if (!btn) return;
+        if (btn.getAttribute('aria-busy') === 'true') {{
+          e.preventDefault();
+          return;
+        }}
+        btn.setAttribute('aria-busy', 'true');
+        btn.disabled = true;
+        btn.textContent = 'Signing in';
+      }});
+    }})();
+  </script>
 </body>
 </html>
 """

--- a/api/routes/import_files.py
+++ b/api/routes/import_files.py
@@ -1445,7 +1445,34 @@ def _render_vault_upload_page() -> str:
               "<code>rollback_import(batch_id=\\"" + escapeHtml(p.batch_id) +
               "\\")</code> from Claude, or " +
               "<code>DELETE /import/" + escapeHtml(p.batch_id) + "</code>.";
+            html +=
+              "<br><br><a href=\\"#\\" id=\\"see-3d\\" " +
+              "style=\\"color:#7e88ff;font-size:13px;text-decoration:none;\\">" +
+              "✨ See it in 3D</a>";
             renderPanel("ok", html);
+            var see3dLink = document.getElementById("see-3d");
+            if (see3dLink) {{
+              see3dLink.addEventListener("click", function (ev) {{
+                ev.preventDefault();
+                var apiKey = null;
+                try {{ apiKey = window.localStorage.getItem(STORAGE_KEY); }} catch (e) {{}}
+                if (!apiKey) {{
+                  alert("Graph not ready. Refresh in 30 seconds.");
+                  return;
+                }}
+                fetch("/import/visualize", {{
+                  headers: {{ "Authorization": "Bearer " + apiKey }}
+                }}).then(function (r) {{
+                  if (!r.ok) throw new Error("not ready");
+                  return r.text();
+                }}).then(function (htmlText) {{
+                  var blob = new Blob([htmlText], {{ type: "text/html" }});
+                  window.open(URL.createObjectURL(blob), "_blank");
+                }}).catch(function () {{
+                  alert("Graph not ready. Refresh in 30 seconds.");
+                }});
+              }});
+            }}
           }} else {{
             var detail = null;
             if (res.payload && res.payload.detail !== undefined) {{
@@ -1516,6 +1543,160 @@ async def vault_upload_page() -> HTMLResponse:
     unauthenticated so the page can render the paste-your-key fallback.
     """
     return HTMLResponse(_render_vault_upload_page())
+
+
+# ---------------------------------------------------------------------------
+# GET /import/visualize — 3D KB preview Easter egg (V2 demo, Sprint 0047)
+# ---------------------------------------------------------------------------
+#
+# Returns a self-contained branded HTML page rendering the caller's whole-org
+# graph using the frontend-supplied template at api/templates/kb_graph_3d.html.
+# Caps: 3000 nodes / 4000 edges. Empty or any error → friendly NOT-READY card.
+
+_VIZ_NODE_CAP = 3000
+_VIZ_EDGE_CAP = 4000
+
+_VIZ_TEMPLATE_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "templates",
+    "kb_graph_3d.html",
+)
+with open(_VIZ_TEMPLATE_PATH, encoding="utf-8") as _fh:
+    _KB_GRAPH_TEMPLATE = _fh.read()
+
+_VIZ_CARD_HTML = """<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<title>xiReactor / Brilliant — Knowledge Graph</title>
+<style>
+  body {{ margin:0; min-height:100vh; background:#0a0c14; color:#e8eaf2;
+    font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    display:flex; align-items:center; justify-content:center; }}
+  .card {{ max-width:480px; padding:32px; text-align:center; }}
+  .brand {{ font-weight:600; letter-spacing:0.04em; color:#7e88ff;
+    font-size:13px; text-transform:uppercase; margin-bottom:16px; }}
+  h1 {{ font-size:24px; margin:0 0 12px; font-weight:600; }}
+  p  {{ margin:0 0 8px; color:#aab0c5; }}
+  .footer {{ position:fixed; bottom:18px; left:0; right:0; text-align:center;
+    font-size:12px; color:#5a6280; }}
+</style></head><body>
+<div class="card">
+  <div class="brand">xiReactor / Brilliant — Knowledge Graph</div>
+  <h1>{title}</h1>
+  <p>{hint}</p>
+</div>
+<div class="footer">xireactor.com/brilliant</div>
+</body></html>"""
+
+
+def _viz_card(title: str, hint: str) -> str:
+    return _VIZ_CARD_HTML.format(title=title, hint=hint)
+
+
+@router.get("/visualize", response_class=HTMLResponse)
+async def visualize_graph(
+    user: UserContext = Depends(get_current_user),
+) -> HTMLResponse:
+    """Render the caller's KB as a self-contained 3D-graph HTML page.
+
+    Bearer api_key required (handled by ``get_current_user``). On the happy
+    path, the frontend-supplied template at ``api/templates/kb_graph_3d.html``
+    is loaded once at module import and the single ``__GRAPH_DATA_JSON__``
+    placeholder is replaced with compact JSON of the graph payload.
+
+    Caps: 3000 nodes / 4000 edges. Above that → branded "exceeds demo
+    limits" card; the heavy template is never invoked. Empty (0 nodes) or
+    any internal error → branded "Graph not ready. Refresh in 30 seconds."
+    card. Errors are logged but never bubbled.
+    """
+    try:
+        async with get_db(user) as conn:
+            cur = await conn.execute(
+                "SELECT COUNT(*) FROM entries WHERE status != 'archived'"
+            )
+            total_nodes = int((await cur.fetchone())[0])
+
+            if total_nodes == 0:
+                return HTMLResponse(
+                    _viz_card("Graph not ready.", "Refresh in 30 seconds.")
+                )
+
+            if total_nodes > _VIZ_NODE_CAP:
+                return HTMLResponse(
+                    _viz_card(
+                        "Wow, you have a large knowledge base.",
+                        "This exceeds the demo visualization limits.",
+                    )
+                )
+
+            cur = await conn.execute(
+                """
+                SELECT id, title, content_type
+                FROM entries
+                WHERE status != 'archived'
+                ORDER BY updated_at DESC
+                """
+            )
+            cur.row_factory = dict_row
+            node_rows = await cur.fetchall()
+            node_ids = [str(r["id"]) for r in node_rows]
+
+            cur = await conn.execute(
+                """
+                SELECT source_entry_id, target_entry_id, link_type
+                FROM entry_links
+                WHERE source_entry_id = ANY(%s)
+                  AND target_entry_id = ANY(%s)
+                """,
+                (node_ids, node_ids),
+            )
+            cur.row_factory = dict_row
+            edge_rows = await cur.fetchall()
+    except Exception:
+        logger.exception("visualize_graph: graph fetch failed")
+        return HTMLResponse(
+            _viz_card("Graph not ready.", "Refresh in 30 seconds.")
+        )
+
+    # Server-side dedup, canonical (min, max, link_type) — mirrors /graph.
+    edge_keys: set[tuple[str, str, str]] = set()
+    edges: list[dict] = []
+    for r in edge_rows:
+        a = str(r["source_entry_id"])
+        b = str(r["target_entry_id"])
+        lo, hi = (a, b) if a <= b else (b, a)
+        key = (lo, hi, r["link_type"])
+        if key in edge_keys:
+            continue
+        edge_keys.add(key)
+        edges.append({"source": lo, "target": hi, "link_type": r["link_type"]})
+
+    if len(edges) > _VIZ_EDGE_CAP:
+        return HTMLResponse(
+            _viz_card(
+                "Wow, you have a large knowledge base.",
+                "This exceeds the demo visualization limits.",
+            )
+        )
+
+    graph_data = {
+        "nodes": [
+            {
+                "id": str(r["id"]),
+                "title": r["title"],
+                "content_type": r["content_type"],
+            }
+            for r in node_rows
+        ],
+        "edges": edges,
+        "truncated": False,
+        "total_nodes": total_nodes,
+    }
+    rendered = _KB_GRAPH_TEMPLATE.replace(
+        "__GRAPH_DATA_JSON__",
+        json.dumps(graph_data, separators=(",", ":")),
+    )
+    return HTMLResponse(rendered)
 
 
 # ---------------------------------------------------------------------------

--- a/api/routes/oauth.py
+++ b/api/routes/oauth.py
@@ -217,6 +217,23 @@ def _render_login(tx: str, email: str = "", error: str | None = None) -> str:
       <button type="submit">Sign in &amp; authorize</button>
     </div>
   </form>
+  <script>
+    (function () {{
+      var form = document.querySelector('form[action="/oauth/login"]');
+      if (!form) return;
+      form.addEventListener('submit', function (e) {{
+        var btn = form.querySelector('button[type=submit]');
+        if (!btn) return;
+        if (btn.getAttribute('aria-busy') === 'true') {{
+          e.preventDefault();
+          return;
+        }}
+        btn.setAttribute('aria-busy', 'true');
+        btn.disabled = true;
+        btn.textContent = 'Signing in';
+      }});
+    }})();
+  </script>
 </body>
 </html>
 """

--- a/api/routes/setup.py
+++ b/api/routes/setup.py
@@ -216,7 +216,7 @@ _BRAND_LOGO_SVG = """<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/sv
 
 _BRAND_TITLE_SVG = """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 72" role="img" aria-label="xiReactor / Brilliant" class="brand-title">
   <text x="260" y="54" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="56" font-weight="700" letter-spacing="-1.2">
-    <tspan fill="#4558c9">xi</tspan><tspan fill="#1f2328">Reactor / </tspan><tspan fill="#4558c9">Brilliant</tspan>
+    <tspan fill="#4558c9">xi</tspan><tspan fill="currentColor">Reactor / </tspan><tspan fill="#4558c9">Brilliant</tspan>
   </text>
 </svg>"""
 
@@ -251,6 +251,17 @@ _BASE_STYLE = """
   button { padding: 10px 14px; font-size: 1rem; background: #111; color: #fff;
            border: 0; border-radius: 6px; cursor: pointer; margin-right: 8px; }
   button:hover { background: #333; }
+  button:disabled, button[aria-busy="true"] {
+    opacity: 0.75; cursor: wait; background: #333;
+  }
+  button[aria-busy="true"]::after {
+    content: ""; display: inline-block; width: 10px; height: 10px;
+    margin-left: 8px; vertical-align: -1px;
+    border: 2px solid rgba(255,255,255,0.4);
+    border-top-color: #fff; border-radius: 50%;
+    animation: brilliant-spin 0.7s linear infinite;
+  }
+  @keyframes brilliant-spin { to { transform: rotate(360deg); } }
   button.secondary { background: #fff; color: #111; border: 1px solid #111; }
   a.button { display: inline-block; padding: 10px 14px; font-size: 1rem;
              background: #111; color: #fff; border: 0; border-radius: 6px;
@@ -277,7 +288,8 @@ _BASE_STYLE = """
   .brand-mark { display: flex; align-items: center; justify-content: center;
                 gap: 14px; margin-bottom: 8px; }
   .brand-logo { width: 56px; height: 56px; flex: 0 0 auto; }
-  .brand-title { height: 42px; width: auto; flex: 0 1 auto; max-width: 360px; }
+  .brand-title { height: 42px; width: auto; flex: 0 1 auto; max-width: 360px;
+                 color: #1f2328; }
   .brand-tagline { color: #555; font-size: 0.95rem; margin: 0; }
 
   /* Pulsing blue CTA for the credentials-download button. The CTA pulses
@@ -358,6 +370,23 @@ def _render_setup_form(
       <button type="submit">Create my admin account</button>
     </div>
   </form>
+  <script>
+    (function () {{
+      var form = document.querySelector('form[action="/setup"]');
+      if (!form) return;
+      form.addEventListener('submit', function (e) {{
+        var btn = form.querySelector('button[type=submit]');
+        if (!btn) return;
+        if (btn.getAttribute('aria-busy') === 'true') {{
+          e.preventDefault();
+          return;
+        }}
+        btn.setAttribute('aria-busy', 'true');
+        btn.disabled = true;
+        btn.textContent = 'Creating account';
+      }});
+    }})();
+  </script>
 </body>
 </html>
 """

--- a/api/templates/kb_graph_3d.html
+++ b/api/templates/kb_graph_3d.html
@@ -1,0 +1,934 @@
+<!doctype html>
+<!--
+  Source: xireactor-brilliant-frontend/.claude/skills/kb-graph-snapshot/template.html @ 28a39ac
+  Backend consumer: xireactor-brilliant — copied to api/templates/kb_graph_3d.html, served by GET /import/visualize.
+  Render contract: backend substitutes the JS-literal data placeholder in the script body (the assignment to `const data`) with compact JSON of GET /graph shape. See BACKEND-HANDOFF.md for the exact token name to keep this comment substitution-safe.
+  Dependency loading: CDN at view time (esm.sh) — three@0.180.0, 3d-force-graph@1.73.3 as ES modules.
+  Network IS required at view time. For an air-gapped (~1–2 MB self-contained) variant, see SKILL.md "Offline variant".
+-->
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>xiReactor / Brilliant — Knowledge Graph</title>
+    <link rel="preconnect" href="https://esm.sh" />
+    <style>
+      :root {
+        --bg-dark: #1e1e2e;
+        --bg-crust: #11111b;
+        --text: #cdd6f4;
+        --text-bright: #f0f0ff;
+        --text-dim: #6c7086;
+        --accent: #89b4fa;
+        --border: #2e2e4a;
+        --red: #f38ba8;
+        --yellow: #f9e2af;
+      }
+      * { box-sizing: border-box; }
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: var(--bg-crust);
+        color: var(--text);
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      #stage {
+        position: fixed;
+        inset: 0;
+        background:
+          radial-gradient(ellipse at center, #1e1e2e 0%, #15151f 55%, #0a0a12 100%);
+      }
+      #stage::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        background: radial-gradient(ellipse at center, transparent 55%, rgba(0,0,0,0.55) 100%);
+      }
+      #graph {
+        position: absolute;
+        inset: 0;
+      }
+      .overlay {
+        position: fixed;
+        pointer-events: none;
+        z-index: 10;
+        text-shadow: 0 1px 4px rgba(0,0,0,0.65);
+      }
+      .brand {
+        top: 24px;
+        left: 28px;
+      }
+      .brand-wordmark {
+        font-size: 22px;
+        font-weight: 700;
+        letter-spacing: 0.3px;
+        color: var(--text-bright);
+      }
+      .brand-wordmark .accent { color: var(--accent); }
+      .brand-wordmark .sep { color: var(--text-dim); font-weight: 400; margin: 0 4px; }
+      .brand-tagline {
+        margin-top: 4px;
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--text-dim);
+      }
+      .meta {
+        bottom: 20px;
+        right: 28px;
+        text-align: right;
+      }
+      .meta-domain {
+        font-size: 11px;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        color: var(--text-dim);
+      }
+      .meta-counts {
+        margin-top: 4px;
+        font-size: 13px;
+        color: var(--text);
+        font-variant-numeric: tabular-nums;
+      }
+      .meta-counts .num { color: var(--text-bright); font-weight: 600; }
+      .meta-counts .truncated {
+        margin-left: 8px;
+        color: var(--yellow);
+        border: 1px solid var(--yellow);
+        border-radius: 4px;
+        padding: 1px 6px;
+        font-size: 10px;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+      .legend {
+        bottom: 20px;
+        left: 28px;
+        display: flex;
+        gap: 14px;
+        flex-wrap: wrap;
+        max-width: 40vw;
+        font-size: 11px;
+        color: var(--text-dim);
+      }
+      .controls {
+        top: 24px;
+        right: 28px;
+        pointer-events: auto;
+        display: flex;
+        gap: 8px;
+      }
+      .icon-btn {
+        appearance: none;
+        width: 34px;
+        height: 34px;
+        border-radius: 50%;
+        border: 1px solid var(--border);
+        background: rgba(17, 17, 27, 0.72);
+        backdrop-filter: blur(4px);
+        color: var(--text-dim);
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        transition: color 120ms ease, border-color 120ms ease, background-color 120ms ease;
+      }
+      .icon-btn:hover { color: var(--text); border-color: var(--accent); }
+      .icon-btn svg { width: 16px; height: 16px; stroke: currentColor; fill: none; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+      .icon-btn.active { color: var(--accent); border-color: var(--accent); }
+      @keyframes pulseShot {
+        0%, 100% {
+          color: var(--text-dim);
+          border-color: var(--border);
+          box-shadow: 0 0 0 0 rgba(137, 180, 250, 0);
+        }
+        50% {
+          color: var(--text-bright);
+          border-color: var(--accent);
+          box-shadow: 0 0 14px 2px rgba(137, 180, 250, 0.45);
+        }
+      }
+      #btn-screenshot { animation: pulseShot 2.4s ease-in-out infinite; }
+      #btn-screenshot:hover, #btn-screenshot:focus-visible { animation: none; }
+      .ctl-panel {
+        top: 70px;
+        right: 28px;
+        pointer-events: auto;
+        width: 232px;
+        background: rgba(17, 17, 27, 0.82);
+        backdrop-filter: blur(6px);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 10px 14px 12px;
+        font-size: 11px;
+        color: var(--text-dim);
+        text-shadow: none;
+      }
+      .ctl-panel.collapsed { display: none; }
+      .ctl-head {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 8px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--text);
+      }
+      .ctl-head button {
+        appearance: none;
+        border: 0;
+        background: transparent;
+        color: var(--text-dim);
+        font: inherit;
+        cursor: pointer;
+        padding: 0 6px;
+        border-radius: 4px;
+        font-size: 14px;
+        line-height: 1;
+      }
+      .ctl-head button:hover { color: var(--text); background: var(--bg-dark); }
+      .ctl-row { margin-bottom: 8px; }
+      .ctl-row:last-of-type { margin-bottom: 0; }
+      .ctl-row label {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 3px;
+        font-variant-numeric: tabular-nums;
+      }
+      .ctl-row label .v { color: var(--text-bright); }
+      .ctl-row input[type="range"] {
+        width: 100%;
+        accent-color: var(--accent);
+      }
+      .ctl-reset {
+        margin-top: 10px;
+        width: 100%;
+        appearance: none;
+        border: 1px solid var(--border);
+        background: transparent;
+        color: var(--text-dim);
+        font: inherit;
+        padding: 5px 8px;
+        border-radius: 6px;
+        cursor: pointer;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      .ctl-reset:hover { color: var(--text); border-color: var(--accent); }
+      .legend .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .legend .dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        box-shadow: 0 0 8px currentColor;
+      }
+      .state {
+        position: fixed;
+        inset: 0;
+        z-index: 20;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+        gap: 10px;
+        color: var(--text-dim);
+        font-size: 14px;
+        pointer-events: none;
+        background: radial-gradient(ellipse at center, rgba(30,30,46,0.7) 0%, rgba(10,10,18,0.85) 100%);
+        backdrop-filter: blur(2px);
+        transition: opacity 1100ms ease-out, backdrop-filter 1100ms ease-out;
+      }
+      .state.hidden { opacity: 0; pointer-events: none; backdrop-filter: blur(0); }
+      .state .spinner {
+        width: 28px;
+        height: 28px;
+        border: 2px solid var(--border);
+        border-top-color: var(--accent);
+        border-radius: 50%;
+        animation: spin 0.9s linear infinite;
+      }
+      @keyframes spin { to { transform: rotate(360deg); } }
+      .state.error { color: var(--red); pointer-events: auto; }
+      .state.error .hint {
+        margin-top: 8px;
+        color: var(--text-dim);
+        font-size: 12px;
+        max-width: 420px;
+        text-align: center;
+        line-height: 1.5;
+      }
+      .state.error code {
+        background: var(--bg-dark);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 1px 6px;
+        color: var(--text);
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 11px;
+      }
+      .state.notice { pointer-events: auto; }
+      .state .card {
+        padding: 22px 30px;
+        background: rgba(17, 17, 27, 0.82);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        backdrop-filter: blur(6px);
+        text-align: center;
+        box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+        max-width: 380px;
+      }
+      .state .card-title {
+        color: var(--text-bright);
+        font-size: 16px;
+        font-weight: 600;
+        margin-bottom: 6px;
+      }
+      .state .card-hint {
+        color: var(--text-dim);
+        font-size: 13px;
+        line-height: 1.5;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="stage">
+      <div id="graph"></div>
+    </div>
+
+    <div class="overlay brand">
+      <div class="brand-wordmark">
+        <span class="accent">xi</span>Reactor<span class="sep">/</span><span class="accent">Brilliant</span>
+      </div>
+      <div class="brand-tagline">Knowledge Graph</div>
+    </div>
+
+    <div class="overlay legend" id="legend"></div>
+
+    <div class="overlay controls">
+      <button type="button" id="btn-tune" class="icon-btn" aria-pressed="false" title="Tune layout">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.01a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.01a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.01a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+      </button>
+      <button type="button" id="btn-playpause" class="icon-btn active" aria-pressed="true" title="Pause rotation">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="6" y="5" width="4" height="14" rx="1"/><rect x="14" y="5" width="4" height="14" rx="1"/></svg>
+      </button>
+      <button type="button" id="btn-screenshot" class="icon-btn" title="Capture screenshot">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/></svg>
+      </button>
+    </div>
+
+    <div class="overlay ctl-panel collapsed" id="ctl-panel">
+      <div class="ctl-head">
+        <span>Tune</span>
+        <button type="button" id="ctl-toggle" aria-label="Close">×</button>
+      </div>
+      <div class="ctl-body">
+        <div class="ctl-row">
+          <label>Repulsion <span class="v" id="v-charge">-10</span></label>
+          <input type="range" id="s-charge" min="-80" max="-1" step="1" value="-10" />
+        </div>
+        <div class="ctl-row">
+          <label>Repulsion range <span class="v" id="v-dmax">250</span></label>
+          <input type="range" id="s-dmax" min="50" max="1000" step="10" value="250" />
+        </div>
+        <div class="ctl-row">
+          <label>Link distance <span class="v" id="v-ldist">18</span></label>
+          <input type="range" id="s-ldist" min="5" max="150" step="1" value="18" />
+        </div>
+        <div class="ctl-row">
+          <label>Stickiness <span class="v" id="v-decay">0.40</span></label>
+          <input type="range" id="s-decay" min="0.05" max="0.95" step="0.01" value="0.40" />
+        </div>
+        <div class="ctl-row">
+          <label>Node size <span class="v" id="v-size">0.35×</span></label>
+          <input type="range" id="s-size" min="0.15" max="3" step="0.05" value="0.35" />
+        </div>
+        <button type="button" class="ctl-reset" id="ctl-reset">Reset</button>
+      </div>
+    </div>
+
+    <div class="overlay meta" id="meta">
+      <div class="meta-domain">xireactor.com/brilliant</div>
+      <div class="meta-counts" id="counts">&nbsp;</div>
+    </div>
+
+    <div id="state" class="state">
+      <div class="spinner"></div>
+      <div>Loading knowledge graph…</div>
+    </div>
+
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://esm.sh/three@0.180.0",
+          "three/": "https://esm.sh/three@0.180.0/"
+        }
+      }
+    </script>
+
+    <script type="module">
+      import * as THREE from "three";
+      import ForceGraph3D from "https://esm.sh/3d-force-graph@1.73.3?external=three";
+
+      // ----- Tuning state (sliders bind to this; render reads from it) -----
+      const CTL_DEFAULTS = { charge: -10, dmax: 250, ldist: 18, decay: 0.40, sizeMul: 0.35 };
+      window.__ctl = { ...CTL_DEFAULTS };
+      window.__applyCtl = () => {};        // overwritten in render3D
+      window.__toggleRotation = () => {};  // overwritten in render3D
+      window.__downloadShot = () => {};    // overwritten in render3D
+
+      function wireControls() {
+        const els = {
+          charge: document.getElementById("s-charge"),
+          dmax:   document.getElementById("s-dmax"),
+          ldist:  document.getElementById("s-ldist"),
+          decay:  document.getElementById("s-decay"),
+          size:   document.getElementById("s-size"),
+        };
+        const readouts = {
+          charge: document.getElementById("v-charge"),
+          dmax:   document.getElementById("v-dmax"),
+          ldist:  document.getElementById("v-ldist"),
+          decay:  document.getElementById("v-decay"),
+          size:   document.getElementById("v-size"),
+        };
+        function sync() {
+          readouts.charge.textContent = window.__ctl.charge;
+          readouts.dmax.textContent   = window.__ctl.dmax;
+          readouts.ldist.textContent  = window.__ctl.ldist;
+          readouts.decay.textContent  = window.__ctl.decay.toFixed(2);
+          readouts.size.textContent   = window.__ctl.sizeMul.toFixed(2) + "×";
+        }
+        function pushToInputs() {
+          els.charge.value = window.__ctl.charge;
+          els.dmax.value   = window.__ctl.dmax;
+          els.ldist.value  = window.__ctl.ldist;
+          els.decay.value  = window.__ctl.decay;
+          els.size.value   = window.__ctl.sizeMul;
+        }
+        // Initialize inputs from defaults so HTML and state agree.
+        pushToInputs();
+        els.charge.addEventListener("input", (e) => { window.__ctl.charge = +e.target.value; sync(); window.__applyCtl(); });
+        els.dmax.addEventListener("input",   (e) => { window.__ctl.dmax = +e.target.value;   sync(); window.__applyCtl(); });
+        els.ldist.addEventListener("input",  (e) => { window.__ctl.ldist = +e.target.value;  sync(); window.__applyCtl(); });
+        els.decay.addEventListener("input",  (e) => { window.__ctl.decay = +e.target.value;  sync(); window.__applyCtl(); });
+        els.size.addEventListener("input",   (e) => { window.__ctl.sizeMul = +e.target.value; sync(); window.__applyCtl({ sizeOnly: true }); });
+        document.getElementById("ctl-reset").addEventListener("click", () => {
+          Object.assign(window.__ctl, CTL_DEFAULTS);
+          pushToInputs(); sync(); window.__applyCtl();
+        });
+        const panel = document.getElementById("ctl-panel");
+        const toggleBtn = document.getElementById("ctl-toggle");
+        const gearBtn = document.getElementById("btn-tune");
+        const setOpen = (open) => {
+          panel.classList.toggle("collapsed", !open);
+          gearBtn.classList.toggle("active", open);
+          gearBtn.setAttribute("aria-pressed", String(open));
+        };
+        toggleBtn.addEventListener("click", () => setOpen(false));
+        gearBtn.addEventListener("click", () => setOpen(panel.classList.contains("collapsed")));
+        sync();
+      }
+
+      function wireActionButtons() {
+        const playBtn = document.getElementById("btn-playpause");
+        const playIcon  = '<svg viewBox="0 0 24 24" aria-hidden="true"><polygon points="6,4 20,12 6,20"/></svg>';
+        const pauseIcon = '<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="6" y="5" width="4" height="14" rx="1"/><rect x="14" y="5" width="4" height="14" rx="1"/></svg>';
+        playBtn.addEventListener("click", () => {
+          const nowRotating = window.__toggleRotation();
+          playBtn.classList.toggle("active", nowRotating);
+          playBtn.setAttribute("aria-pressed", String(nowRotating));
+          playBtn.title = nowRotating ? "Pause rotation" : "Resume rotation";
+          playBtn.innerHTML = nowRotating ? pauseIcon : playIcon;
+        });
+        document.getElementById("btn-screenshot").addEventListener("click", () => window.__downloadShot());
+      }
+
+      // ----- Config -----
+      const CONTENT_TYPE_COLORS = {
+        concept: "#89b4fa",      // blue
+        policy: "#f38ba8",       // red
+        procedure: "#a6e3a1",    // green
+        decision: "#f9e2af",     // yellow
+        reference: "#cba6f7",    // purple
+        note: "#94e2d5",         // teal
+        project: "#fab387",      // orange
+        person: "#f5c2e7",       // pink
+        meeting: "#74c7ec",      // sky
+        organization: "#b4befe", // lavender
+        event: "#eba0ac",        // maroon
+        task: "#f2cdcd",         // flamingo
+      };
+      const DEFAULT_COLOR = "#9399b2";  // muted gray — visibly distinct from any mapped type
+      const HIGHLIGHT_COLOR = "#f9e2af";
+
+      const stateEl = document.getElementById("state");
+      const countsEl = document.getElementById("counts");
+      const legendEl = document.getElementById("legend");
+
+      function showError(title, hint) {
+        stateEl.classList.remove("hidden");
+        stateEl.classList.add("error");
+        stateEl.innerHTML = `
+          <div>${title}</div>
+          ${hint ? `<div class="hint">${hint}</div>` : ""}
+        `;
+      }
+
+      function showNotice(title, hint) {
+        stateEl.classList.remove("hidden");
+        stateEl.classList.add("notice");
+        stateEl.innerHTML = `
+          <div class="card">
+            <div class="card-title">${title}</div>
+            ${hint ? `<div class="card-hint">${hint}</div>` : ""}
+          </div>
+        `;
+      }
+
+      function hideState() {
+        stateEl.classList.add("hidden");
+      }
+
+      // ----- Render -----
+      function buildLegend(presentTypes) {
+        const entries = Array.from(presentTypes)
+          .sort()
+          .map((t) => {
+            const color = CONTENT_TYPE_COLORS[t] || DEFAULT_COLOR;
+            return `<span class="chip"><span class="dot" style="color:${color};background:${color}"></span>${t}</span>`;
+          });
+        legendEl.innerHTML = entries.join("");
+      }
+
+      function prepareData(data) {
+        const nodes = data.nodes.map((n) => ({
+          id: n.id,
+          title: n.title,
+          content_type: n.content_type,
+          color: CONTENT_TYPE_COLORS[n.content_type] || DEFAULT_COLOR,
+        }));
+        const nodeIds = new Set(nodes.map((n) => n.id));
+        const links = (data.edges || [])
+          .filter((e) => nodeIds.has(e.source) && nodeIds.has(e.target))
+          .map((e) => ({
+            source: e.source,
+            target: e.target,
+            link_type: e.link_type,
+          }));
+
+        // Degree map → drives node sizing
+        const degreeMap = new Map();
+        links.forEach((l) => {
+          degreeMap.set(l.source, (degreeMap.get(l.source) || 0) + 1);
+          degreeMap.set(l.target, (degreeMap.get(l.target) || 0) + 1);
+        });
+        nodes.forEach((n) => { n.degree = degreeMap.get(n.id) || 0; });
+
+        const presentTypes = new Set(nodes.map((n) => n.content_type));
+        buildLegend(presentTypes);
+
+        const countLabel =
+          `<span class="num">${nodes.length}</span> entries · ` +
+          `<span class="num">${links.length}</span> links` +
+          (data.truncated
+            ? `<span class="truncated" title="Showing ${nodes.length} of ${data.total_nodes}">truncated</span>`
+            : "");
+        countsEl.innerHTML = countLabel;
+
+        return { nodes, links };
+      }
+
+      function render3D({ nodes, links }) {
+        // ----- Sprite halo texture (soft radial glow) -----
+        const haloTex = (() => {
+          const size = 128;
+          const canvas = document.createElement("canvas");
+          canvas.width = canvas.height = size;
+          const ctx = canvas.getContext("2d");
+          const g = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+          g.addColorStop(0.0, "rgba(255,255,255,1.0)");
+          g.addColorStop(0.3, "rgba(255,255,255,0.55)");
+          g.addColorStop(0.7, "rgba(255,255,255,0.08)");
+          g.addColorStop(1.0, "rgba(255,255,255,0.0)");
+          ctx.fillStyle = g;
+          ctx.fillRect(0, 0, size, size);
+          const t = new THREE.Texture(canvas);
+          t.needsUpdate = true;
+          return t;
+        })();
+
+        function nodeObject(node) {
+          const group = new THREE.Group();
+          const color = new THREE.Color(node.color);
+
+          // sqrt scaling: 0→1.0x, 1→1.25x, 10→1.79x, 100→3.5x — multiplied by user-tunable sizeMul.
+          const scale = (1 + Math.sqrt(node.degree || 0) * 0.45) * (window.__ctl?.sizeMul ?? 1);
+
+          // core sphere
+          const core = new THREE.Mesh(
+            new THREE.SphereGeometry(3.2 * scale, 16, 16),
+            new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.95 })
+          );
+          group.add(core);
+
+          // additive halo sprite
+          const halo = new THREE.Sprite(
+            new THREE.SpriteMaterial({
+              map: haloTex,
+              color,
+              transparent: true,
+              blending: THREE.AdditiveBlending,
+              depthWrite: false,
+              opacity: 0.9,
+            })
+          );
+          const haloSize = 16 * scale;
+          halo.scale.set(haloSize, haloSize, 1);
+          group.add(halo);
+
+          return group;
+        }
+
+        const graph = ForceGraph3D({
+          rendererConfig: { antialias: true, alpha: true, preserveDrawingBuffer: true }
+        })(document.getElementById("graph"))
+          .backgroundColor("rgba(0,0,0,0)")
+          .graphData({ nodes, links })
+          .nodeId("id")
+          .nodeLabel((n) => `<div style="font-size:12px;color:#f0f0ff;padding:4px 8px;background:#1e1e2e;border:1px solid #2e2e4a;border-radius:6px;box-shadow:0 4px 16px rgba(0,0,0,0.5)"><strong>${n.title}</strong><div style="color:#6c7086;font-size:10px;margin-top:2px;text-transform:uppercase;letter-spacing:0.12em">${n.content_type}</div></div>`)
+          .nodeThreeObject(nodeObject)
+          .nodeRelSize(4)
+          .linkColor(() => "rgba(205, 214, 244, 0.38)")
+          .linkWidth(0.7)
+          .linkOpacity(0.8)
+          .linkDirectionalParticles(1)
+          .linkDirectionalParticleWidth(1.2)
+          .linkDirectionalParticleSpeed(0.002)
+          .linkDirectionalParticleColor(() => "rgba(137, 180, 250, 0.9)")
+          .cooldownTicks(200)
+          .warmupTicks(20)
+          .showNavInfo(false);
+
+        // Initial force config — same numbers slider defaults bind to.
+        graph.d3Force("charge").strength(window.__ctl.charge).distanceMax(window.__ctl.dmax);
+        if (graph.d3Force("link")) graph.d3Force("link").distance(window.__ctl.ldist);
+        if (typeof graph.d3VelocityDecay === "function") graph.d3VelocityDecay(window.__ctl.decay);
+
+        // Slider-driven retune (called on every input change).
+        window.__applyCtl = (opts = {}) => {
+          graph.d3Force("charge").strength(window.__ctl.charge).distanceMax(window.__ctl.dmax);
+          if (graph.d3Force("link")) graph.d3Force("link").distance(window.__ctl.ldist);
+          if (typeof graph.d3VelocityDecay === "function") graph.d3VelocityDecay(window.__ctl.decay);
+          if (opts.sizeOnly) {
+            // Reassign the same nodeThreeObject fn — invalidates the lib's per-node cache so
+            // the new sizeMul is picked up without disturbing the simulation.
+            graph.nodeThreeObject(nodeObject);
+          } else if (typeof graph.d3ReheatSimulation === "function") {
+            graph.d3ReheatSimulation();
+          }
+        };
+
+        // Transparent canvas so our CSS gradient shows through
+        graph.renderer().setClearColor(0x000000, 0);
+
+        // ----- Auto-rotate camera around origin on Y axis -----
+        const RADIUS_FLOOR = 260;
+        const ROT_SECONDS = 75; // one full turn every ~75s
+        const angularSpeed = (Math.PI * 2) / (ROT_SECONDS * 1000);
+        let angle = 0;
+        let lastTs = performance.now();
+        let rotating = true;
+        let resumeTimer = null;
+
+        // Initial camera distance — scales gently with node count.
+        // This is a placeholder; refitCameraTo90thPercentile() below replaces it
+        // once the simulation cools, so the main cluster fills the frame instead
+        // of being squashed to fit a few far-flung disconnected outliers.
+        const initialZ = Math.max(RADIUS_FLOOR, 22 * Math.sqrt(Math.max(nodes.length, 1)));
+        graph.cameraPosition({ x: 0, y: 0, z: initialZ }, undefined, 0);
+
+        // After the engine settles, snap camera so 95% of nodes are in frame.
+        // Force-graph's default `center` force pins the cluster centroid near origin,
+        // so distance-from-origin is a fine proxy for distance-from-centroid here.
+        // Spinner stays up until this fires so the user only ever sees the settled,
+        // properly-framed pose — never the placeholder distance or a zoom animation.
+        let refitDone = false;
+        function refitCameraTo90thPercentile() {
+          if (refitDone) return;
+          refitDone = true;
+          const dists = nodes
+            .map((n) => Math.hypot(n.x || 0, n.y || 0, n.z || 0))
+            .sort((a, b) => a - b);
+          if (dists.length) {
+            const R = dists[Math.floor(dists.length * 0.95)] || RADIUS_FLOOR;
+            const camera = graph.camera && graph.camera();
+            const vfovDeg = (camera && camera.fov) || 50;
+            const vfovRad = (vfovDeg * Math.PI) / 180;
+            // Frame radius R at distance D = R / tan(vfov/2), with 15% breathing room.
+            const D = Math.max(RADIUS_FLOOR, (R / Math.tan(vfovRad / 2)) * 1.15);
+            // Pause auto-rotate so the lib's own camera tween isn't overwritten each frame.
+            // Rotation resumes after the transition, which runs in tandem with the
+            // overlay's CSS opacity fade — masks the motion so there's no pop.
+            const REVEAL_MS = 1100;
+            rotating = false;
+            graph.cameraPosition({ x: 0, y: 0, z: D }, { x: 0, y: 0, z: 0 }, REVEAL_MS);
+            setTimeout(() => {
+              if (userPaused) return;
+              const c = graph.cameraPosition();
+              angle = Math.atan2(c.x, c.z);
+              rotating = true;
+            }, REVEAL_MS + 50);
+          }
+          hideState();
+        }
+        graph.onEngineStop(refitCameraTo90thPercentile);
+        // Fallback: if the engine somehow never reports stop (e.g. tiny graph, or a
+        // pathological layout), don't leave the user staring at a spinner forever.
+        setTimeout(refitCameraTo90thPercentile, 6000);
+
+        // User-driven (button) toggle — sticky, no auto-resume.
+        let userPaused = false;
+
+        // Mouse-drag / wheel pause — temporary, auto-resumes after 2.5s if user hasn't toggled.
+        function nudgePause() {
+          if (userPaused) return;
+          rotating = false;
+          if (resumeTimer) clearTimeout(resumeTimer);
+          resumeTimer = setTimeout(() => {
+            if (userPaused) return;
+            const c = graph.cameraPosition();
+            angle = Math.atan2(c.x, c.z);
+            rotating = true;
+          }, 2500);
+        }
+
+        window.__toggleRotation = () => {
+          userPaused = !userPaused;
+          if (userPaused) {
+            rotating = false;
+            if (resumeTimer) { clearTimeout(resumeTimer); resumeTimer = null; }
+          } else {
+            const c = graph.cameraPosition();
+            angle = Math.atan2(c.x, c.z);
+            rotating = true;
+          }
+          return !userPaused; // true = now rotating
+        };
+
+        // Social-share screenshot: 4:3 PNG with brand chrome composited in canvas2D.
+        const SHOT_W = 1600;
+        const SHOT_H = 1200;
+
+        function drawChrome(ctx, W, H) {
+          ctx.save();
+          ctx.shadowColor = "rgba(0,0,0,0.7)";
+          ctx.shadowBlur = 6;
+          ctx.shadowOffsetY = 2;
+
+          // Top-left wordmark — large, social-prominent
+          const mx = 56, my = 100;
+          const sansBold = '700 56px ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+          const sansThin = '400 56px ui-sans-serif, system-ui, sans-serif';
+          ctx.textBaseline = "alphabetic";
+          let x = mx;
+          ctx.font = sansBold;
+          ctx.fillStyle = "#89b4fa"; ctx.fillText("xi", x, my); x += ctx.measureText("xi").width;
+          ctx.fillStyle = "#f0f0ff"; ctx.fillText("Reactor", x, my); x += ctx.measureText("Reactor").width;
+          ctx.font = sansThin;
+          ctx.fillStyle = "#6c7086"; ctx.fillText(" / ", x, my); x += ctx.measureText(" / ").width;
+          ctx.font = sansBold;
+          ctx.fillStyle = "#89b4fa"; ctx.fillText("Brilliant", x, my);
+
+          // Tagline
+          ctx.font = "20px ui-sans-serif, system-ui, sans-serif";
+          ctx.letterSpacing = "0.24em";
+          ctx.fillStyle = "#9399b2";
+          ctx.fillText("KNOWLEDGE GRAPH", mx, my + 36);
+          ctx.letterSpacing = "0px";
+
+          // Bottom-left legend (only types actually present)
+          const presentTypes = Array.from(new Set(nodes.map((n) => n.content_type))).sort();
+          ctx.font = "20px ui-sans-serif, system-ui, sans-serif";
+          ctx.textBaseline = "middle";
+          ctx.textAlign = "left";
+          let lx = 56;
+          const ly = H - 60;
+          presentTypes.forEach((t) => {
+            const color = CONTENT_TYPE_COLORS[t] || DEFAULT_COLOR;
+            // halo dot
+            ctx.fillStyle = color;
+            ctx.shadowColor = color;
+            ctx.shadowBlur = 14;
+            ctx.beginPath();
+            ctx.arc(lx + 8, ly, 8, 0, Math.PI * 2);
+            ctx.fill();
+            // label
+            ctx.shadowBlur = 6;
+            ctx.shadowColor = "rgba(0,0,0,0.7)";
+            ctx.fillStyle = "#bac2de";
+            ctx.fillText(t, lx + 26, ly);
+            lx += 26 + ctx.measureText(t).width + 26;
+          });
+
+          // Bottom-right domain + counts
+          const rx = W - 56;
+          ctx.textBaseline = "alphabetic";
+          ctx.textAlign = "right";
+          ctx.font = "18px ui-sans-serif, system-ui, sans-serif";
+          ctx.letterSpacing = "0.24em";
+          ctx.fillStyle = "#9399b2";
+          ctx.fillText("XIREACTOR.COM/BRILLIANT", rx, H - 80);
+          ctx.letterSpacing = "0px";
+
+          // Counts: bold numbers + dim units, right-aligned
+          const segs = [
+            { t: String(nodes.length), bold: true },
+            { t: " entries · ", bold: false },
+            { t: String(links.length), bold: true },
+            { t: " links", bold: false },
+          ];
+          let totalW = 0;
+          segs.forEach((s) => {
+            ctx.font = s.bold ? "600 24px ui-sans-serif, system-ui, sans-serif" : "24px ui-sans-serif, system-ui, sans-serif";
+            s.w = ctx.measureText(s.t).width;
+            totalW += s.w;
+          });
+          ctx.textAlign = "left";
+          ctx.textBaseline = "middle";
+          let cxr = rx - totalW;
+          segs.forEach((s) => {
+            ctx.font = s.bold ? "600 24px ui-sans-serif, system-ui, sans-serif" : "24px ui-sans-serif, system-ui, sans-serif";
+            ctx.fillStyle = s.bold ? "#f0f0ff" : "#cdd6f4";
+            ctx.fillText(s.t, cxr, H - 44);
+            cxr += s.w;
+          });
+
+          ctx.restore();
+        }
+
+        window.__downloadShot = () => {
+          const renderer = graph.renderer();
+          const scene = graph.scene();
+          const camera = graph.camera();
+
+          // Save current size + aspect
+          const origW = renderer.domElement.width;
+          const origH = renderer.domElement.height;
+          const origAspect = camera.aspect;
+          const origPixelRatio = renderer.getPixelRatio();
+
+          // Render scene at 4:3 capture resolution (offscreen, no DOM reflow because updateStyle=false)
+          renderer.setPixelRatio(1);
+          renderer.setSize(SHOT_W, SHOT_H, false);
+          camera.aspect = SHOT_W / SHOT_H;
+          camera.updateProjectionMatrix();
+          renderer.render(scene, camera);
+
+          // Composite onto a 2D canvas: gradient bg → WebGL frame → vignette → branded chrome
+          const out = document.createElement("canvas");
+          out.width = SHOT_W;
+          out.height = SHOT_H;
+          const ctx = out.getContext("2d");
+
+          const cx = SHOT_W / 2, cy = SHOT_H / 2;
+          const rad = Math.max(SHOT_W, SHOT_H) / 1.4;
+          const bg = ctx.createRadialGradient(cx, cy, 0, cx, cy, rad);
+          bg.addColorStop(0.0, "#1e1e2e");
+          bg.addColorStop(0.55, "#15151f");
+          bg.addColorStop(1.0, "#0a0a12");
+          ctx.fillStyle = bg;
+          ctx.fillRect(0, 0, SHOT_W, SHOT_H);
+
+          ctx.drawImage(renderer.domElement, 0, 0, SHOT_W, SHOT_H);
+
+          // Soft vignette to match CSS #stage::after
+          const vg = ctx.createRadialGradient(cx, cy, 0, cx, cy, rad);
+          vg.addColorStop(0.55, "rgba(0,0,0,0)");
+          vg.addColorStop(1.0, "rgba(0,0,0,0.55)");
+          ctx.fillStyle = vg;
+          ctx.fillRect(0, 0, SHOT_W, SHOT_H);
+
+          drawChrome(ctx, SHOT_W, SHOT_H);
+
+          // Restore renderer to on-screen size + re-render so the live view doesn't flicker
+          renderer.setPixelRatio(origPixelRatio);
+          renderer.setSize(origW / origPixelRatio, origH / origPixelRatio, false);
+          camera.aspect = origAspect;
+          camera.updateProjectionMatrix();
+          renderer.render(scene, camera);
+
+          out.toBlob((blob) => {
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement("a");
+            link.download = `brilliant-graph-${new Date().toISOString().slice(0, 10)}.png`;
+            link.href = url;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            setTimeout(() => URL.revokeObjectURL(url), 1000);
+          }, "image/png");
+        };
+
+        const controls = graph.controls();
+        if (controls && controls.addEventListener) {
+          controls.addEventListener("start", nudgePause);
+        }
+        document.getElementById("graph").addEventListener("wheel", nudgePause, { passive: true });
+
+        function tick(ts) {
+          const dt = ts - lastTs;
+          lastTs = ts;
+          if (rotating) {
+            angle += angularSpeed * dt;
+            const c = graph.cameraPosition();
+            const r = Math.hypot(c.x, c.z) || initialZ;
+            graph.cameraPosition(
+              { x: Math.sin(angle) * r, y: c.y, z: Math.cos(angle) * r },
+              undefined,
+              0
+            );
+          }
+          requestAnimationFrame(tick);
+        }
+        requestAnimationFrame(tick);
+
+        const resize = () => graph.width(window.innerWidth).height(window.innerHeight);
+        window.addEventListener("resize", resize);
+        resize();
+
+        return {
+          destroy() {
+            rotating = false;
+            if (resumeTimer) clearTimeout(resumeTimer);
+            window.removeEventListener("resize", resize);
+            if (graph._destructor) graph._destructor();
+          },
+        };
+      }
+
+      // ----- Go -----
+      wireControls();
+      wireActionButtons();
+      const data = __GRAPH_DATA_JSON__;
+      // Spinner stays visible until refitCameraTo90thPercentile() fires on engine stop
+      // (or its 6s fallback) — gives the user a single clean reveal at the framed pose.
+      if (!data.nodes || data.nodes.length === 0) {
+        showNotice(
+          "Graph not ready.",
+          "Refresh in 30 seconds."
+        );
+      } else {
+        const prepared = prepareData(data);
+        document.getElementById("graph").innerHTML = "";
+        render3D(prepared);
+      }
+    </script>
+  </body>
+</html>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,11 @@ services:
       context: .
       dockerfile: ./api/Dockerfile
     # No `container_name:` — see db service comment (T-0259).
+    # `command:` override adds --reload for local dev (the ./api:/app
+    # bind mount below makes hot-reload meaningful). Dockerfile CMD is
+    # kept production-clean for Render so we don't have to fight
+    # Render's dockerCommand quote-parsing bug.
+    command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
     depends_on:
       db:
         condition: service_healthy

--- a/mcp/client.py
+++ b/mcp/client.py
@@ -22,26 +22,35 @@ import httpx
 def _resolve_api_base_url() -> str:
     """Resolve the API's outbound-callable base URL (mcp → api tool calls).
 
-    Env-only resolution (T-0264.4, Sprint 0045):
+    Resolution order:
 
-    1. ``BRILLIANT_BASE_URL`` — the canonical outbound URL. Compose sets
-       this to ``http://api:8000`` (service-network address); ``render.yaml``
-       wires it via ``fromService.property:host`` (internal service name).
-       On Render this is bare; we prepend ``https://`` if no scheme is
-       present.
-    2. ``http://localhost:8010`` — last-resort default for local-dev /
-       debug runs without compose.
+    1. ``BRILLIANT_API_HOST`` + ``BRILLIANT_API_PORT`` — the Render path.
+       render.yaml wires both via ``fromService`` against the API service
+       (``property: host`` and ``property: port``), so the URL stays
+       generic across forks/renames. Render's inter-service mesh is plain
+       HTTP (no internal TLS termination), so we always assemble
+       ``http://<host>:<port>``.
+    2. ``BRILLIANT_BASE_URL`` — explicit full URL for compose / local-dev
+       (e.g. ``http://api:8000``). Bare values (no scheme) are treated as
+       ``http://<value>`` — *not* https://, since prepending https against
+       a plain-HTTP internal endpoint silently fails ("All connection
+       attempts failed").
+    3. ``http://localhost:8010`` — last-resort default for ad-hoc runs.
 
-    DB read of ``brilliant_settings.api_public_url`` was removed. That
-    column is semantically the *browser-visible* URL (used by
-    ``mcp/remote_server.py::_resolve_api_public_url`` to build OAuth
+    DB read of ``brilliant_settings.api_public_url`` was removed in
+    T-0264.4. That column is semantically the *browser-visible* URL (used
+    by ``mcp/remote_server.py::_resolve_api_public_url`` to build OAuth
     redirects); reading it for outbound poisoned mcp→api calls any time
-    an operator set it for OAuth reasons. See ST-0209 / demo4 incident
-    for the exact failure this guards against.
+    an operator set it for OAuth reasons. See ST-0209 / demo4 incident.
     """
+    host = os.environ.get("BRILLIANT_API_HOST", "").strip()
+    port = os.environ.get("BRILLIANT_API_PORT", "").strip()
+    if host and port:
+        return f"http://{host}:{port}".rstrip("/")
+
     raw = os.environ.get("BRILLIANT_BASE_URL", "http://localhost:8010").strip()
     if raw and not raw.startswith(("http://", "https://")):
-        raw = f"https://{raw}"
+        raw = f"http://{raw}"
     return raw.rstrip("/")
 
 

--- a/mcp/remote_server.py
+++ b/mcp/remote_server.py
@@ -672,6 +672,15 @@ mcp.settings.debug = False
 # fresh /oauth/login POST, which re-computes the sig anyway.
 
 
+@mcp.custom_route("/", methods=["GET", "HEAD"])
+async def _root_health(request: Request) -> Response:
+    # Render's port-detector + continuous health probe issues HEAD /. Without
+    # a handler here FastMCP's streamable_http_app returns 404, which Render
+    # treats as unhealthy and tears the container down ~60s after going live
+    # (no auto-restart). 200 OK keeps the deploy healthy.
+    return PlainTextResponse("ok")
+
+
 @mcp.custom_route("/oauth/continue", methods=["GET"])
 async def _oauth_continue(request: Request) -> Response:
     tx = (request.query_params.get("tx") or "").strip()

--- a/mcp/remote_server.py
+++ b/mcp/remote_server.py
@@ -162,7 +162,9 @@ class _BasicAuthTokenBodyBridge:
 # Configuration
 # ---------------------------------------------------------------------------
 
-MCP_PORT = int(os.environ.get("MCP_PORT", "8001"))
+# Render injects $PORT and expects the service to bind it; MCP_PORT is kept
+# for compose / local-dev (and as the ultimate fallback). PORT wins on Render.
+MCP_PORT = int(os.environ.get("PORT") or os.environ.get("MCP_PORT", "8001"))
 _RENDER_EXTERNAL_URL = os.environ.get("RENDER_EXTERNAL_URL", "").strip()
 _MCP_BASE_URL_RAW = os.environ.get("MCP_BASE_URL", "").strip()
 

--- a/mcp/requirements.txt
+++ b/mcp/requirements.txt
@@ -1,3 +1,8 @@
-mcp[cli]>=1.27
+mcp[cli]>=1.27,<2
+# Pin pre-1.0 starlette: streamable HTTP MCP transport regresses on
+# starlette 1.0.0 (2026-03-22 release). Symptom: server returns 200 OK
+# on POST + GET /mcp; client receives no usable SSE stream.
+starlette<1.0
+uvicorn<0.46
 httpx>=0.27
 psycopg[binary]>=3.1

--- a/mcp/requirements.txt
+++ b/mcp/requirements.txt
@@ -1,7 +1,10 @@
 mcp[cli]>=1.27,<2
-# Pin pre-1.0 starlette: streamable HTTP MCP transport regresses on
-# starlette 1.0.0 (2026-03-22 release). Symptom: server returns 200 OK
-# on POST + GET /mcp; client receives no usable SSE stream.
+# Pin pre-3.4 sse-starlette: streamable HTTP MCP transport regresses on
+# sse-starlette 3.4.1 (released 2026-04-26). Symptom: server returns
+# 200 OK on POST + GET /mcp; client receives no usable SSE stream.
+sse-starlette<3.4
+# Pin pre-1.0 starlette + pre-0.46 uvicorn as belt-and-braces — the
+# same fresh-install resolved both alongside sse-starlette 3.4.1.
 starlette<1.0
 uvicorn<0.46
 httpx>=0.27

--- a/mcp/wait_for_api_migrations.py
+++ b/mcp/wait_for_api_migrations.py
@@ -1,0 +1,81 @@
+"""Block the MCP's deploy until the API has finished migrating the DB.
+
+Render Blueprint runs each service's deploy lane independently — there is
+no native cross-service `depends_on`. Without coordination the MCP can
+boot before brilliant-api's `preDeployCommand: python tools/render_migrate.py`
+has finished, which produces `role "kb_admin" does not exist` from
+`_publish_public_url_to_db()` at module-import time.
+
+This script is run as the MCP's `preDeployCommand`. It polls the shared DB
+for the `kb_admin` role, which 004_rls.sql creates. render_migrate.py
+applies migrations in numeric order with one transaction per file, so once
+kb_admin exists, 004 has committed and every later migration has either
+committed or is mid-flight under its own tx — safe to proceed.
+
+Exit codes:
+    0  — kb_admin role visible; safe to deploy MCP
+    1  — timed out (deploy is blocked)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import psycopg
+
+
+TIMEOUT_SECONDS = 240
+POLL_INTERVAL_SECONDS = 3
+CONNECT_TIMEOUT_SECONDS = 5
+
+
+def main() -> int:
+    dsn = os.environ.get("DATABASE_URL", "").strip()
+    if not dsn:
+        # Compose / local dev paths run this script too only if explicitly
+        # wired in. Treat absence as "not on Render, skip the gate."
+        print("DATABASE_URL not set — skipping wait", flush=True)
+        return 0
+
+    deadline = time.time() + TIMEOUT_SECONDS
+    attempt = 0
+    while time.time() < deadline:
+        attempt += 1
+        try:
+            with psycopg.connect(dsn, connect_timeout=CONNECT_TIMEOUT_SECONDS) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT 1 FROM pg_roles WHERE rolname = 'kb_admin'"
+                    )
+                    if cur.fetchone():
+                        print(
+                            f"API migrations ready (kb_admin present, "
+                            f"attempt={attempt})",
+                            flush=True,
+                        )
+                        return 0
+            print(
+                f"Waiting for API migrations… (attempt={attempt}, "
+                f"kb_admin not yet created)",
+                flush=True,
+            )
+        except Exception as exc:  # noqa: BLE001 — DB may be reachable mid-deploy
+            print(
+                f"Waiting for DB / migrations (attempt={attempt}): {exc}",
+                flush=True,
+            )
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+    print(
+        f"Timed out after {TIMEOUT_SECONDS}s waiting for kb_admin role; "
+        f"check brilliant-api preDeployCommand logs.",
+        file=sys.stderr,
+        flush=True,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/render.yaml
+++ b/render.yaml
@@ -42,13 +42,16 @@ services:
     name: brilliant-api
     runtime: docker
     plan: starter
-    region: oregon
+    region: virginia
     dockerfilePath: ./api/Dockerfile
     dockerContext: .
     # Override the Dockerfile CMD to drop `--reload` in production.
     # Render's Docker runtime uses `dockerCommand` (not `startCommand`,
-    # which is native-runtime only). `sh -c` so $PORT expands at runtime.
-    dockerCommand: sh -c "uvicorn main:app --host 0.0.0.0 --port $PORT"
+    # which is native-runtime only). Hardcode port 8000 to match the
+    # PORT env var below — Render preserves literal double quotes from
+    # YAML into argv, so `sh -c "$PORT"` forms get executed as a single
+    # quoted command name and fail with "not found".
+    dockerCommand: uvicorn main:app --host 0.0.0.0 --port 8000
     # Runs before every deploy (Render executes this inside the built
     # image against the live DB). Idempotent migrations 001..NNN.
     preDeployCommand: python tools/render_migrate.py
@@ -131,7 +134,7 @@ services:
     name: brilliant-mcp
     runtime: docker
     plan: starter
-    region: oregon
+    region: virginia
     dockerfilePath: ./mcp/Dockerfile
     dockerContext: ./mcp
     # Dockerfile CMD `python remote_server.py` is fine for production —

--- a/render.yaml
+++ b/render.yaml
@@ -45,13 +45,13 @@ services:
     region: virginia
     dockerfilePath: ./api/Dockerfile
     dockerContext: .
-    # Override the Dockerfile CMD to drop `--reload` in production.
-    # Render's Docker runtime uses `dockerCommand` (not `startCommand`,
-    # which is native-runtime only). Hardcode port 8000 to match the
-    # PORT env var below — Render preserves literal double quotes from
-    # YAML into argv, so `sh -c "$PORT"` forms get executed as a single
-    # quoted command name and fail with "not found".
-    dockerCommand: uvicorn main:app --host 0.0.0.0 --port 8000
+    # NO `dockerCommand:` — Render's parser wraps the value in literal
+    # quotes and passes it through `sh -c '"<value>"'`, which sh treats
+    # as a single quoted command name and fails with `sh: 1: <value>: not
+    # found` (exit 127). Both the `sh -c "..."` form and the bare form
+    # hit this. The Dockerfile CMD is production-ready exec-form (no
+    # --reload), so we let it run as-is. Local dev keeps --reload via
+    # `command:` override in docker-compose.yml.
     # Runs before every deploy (Render executes this inside the built
     # image against the live DB). Idempotent migrations 001..NNN.
     preDeployCommand: python tools/render_migrate.py

--- a/render.yaml
+++ b/render.yaml
@@ -30,6 +30,7 @@ databases:
   - name: brilliant-db
     plan: basic-256mb
     databaseName: brilliant
+    region: virginia
     # user omitted — Render auto-generates the DB user; `postgres` is reserved
     # and rejected by Blueprint validation. DATABASE_URL still resolves via
     # `fromDatabase.property: connectionString` below.

--- a/render.yaml
+++ b/render.yaml
@@ -47,16 +47,25 @@ services:
     dockerContext: .
     # Override the Dockerfile CMD to drop `--reload` in production.
     # Render's Docker runtime uses `dockerCommand` (not `startCommand`,
-    # which is native-runtime only).
-    dockerCommand: uvicorn main:app --host 0.0.0.0 --port 8000
+    # which is native-runtime only). `sh -c` so $PORT expands at runtime.
+    dockerCommand: sh -c "uvicorn main:app --host 0.0.0.0 --port $PORT"
     # Runs before every deploy (Render executes this inside the built
-    # image against the live DB). Idempotent migrations 001..027.
+    # image against the live DB). Idempotent migrations 001..NNN.
     preDeployCommand: python tools/render_migrate.py
     disk:
       name: brilliant-data
       mountPath: /data
       sizeGB: 1
     envVars:
+      # --- Port ---
+      # Tell Render the port up front so its port-detector doesn't loop
+      # ("New primary port detected. Restarting deploy to update network
+      # configuration...") when the service binds something other than
+      # Render's default ($PORT=10000). dockerCommand binds $PORT, so the
+      # service binds whatever this value is.
+      - key: PORT
+        value: "8000"
+
       # --- Database ---
       - key: DATABASE_URL
         fromDatabase:
@@ -125,33 +134,57 @@ services:
     region: oregon
     dockerfilePath: ./mcp/Dockerfile
     dockerContext: ./mcp
-    # Dockerfile CMD `python remote_server.py` is fine for production.
+    # Dockerfile CMD `python remote_server.py` is fine for production —
+    # remote_server.py reads PORT (set below) and binds it.
+    #
+    # Pre-deploy: block until the API's preDeployCommand (render_migrate.py)
+    # has finished applying the schema. We poll for the kb_admin role; once
+    # 004_rls.sql has run, the catalog is populated and every later migration
+    # has run too (render_migrate.py applies in order, transactionally per
+    # file). Without this, the MCP container can boot before the API has
+    # finished migrating a fresh DB and `_publish_public_url_to_db()` fails
+    # with `role "kb_admin" does not exist`.
+    preDeployCommand: python wait_for_api_migrations.py
     envVars:
+      # --- Port ---
+      # Same rationale as brilliant-api above: Render's port-detector loops
+      # when the bound port disagrees with $PORT. remote_server.py reads
+      # PORT first, MCP_PORT second, default 8001.
+      - key: PORT
+        value: "8001"
+
       # --- Database (for OAuth store + session logs) ---
       - key: DATABASE_URL
         fromDatabase:
           name: brilliant-db
           property: connectionString
 
-      # --- API base URL (internal-to-Render service-discovery name) ---
-      # Render returns the internal service name (e.g. "brilliant-api") here,
-      # NOT the public FQDN. mcp/client.py prepends `https://` when building
-      # the outbound URL — internal-network resolution on Render maps the
-      # bare name to the service. If you ever need a public URL here, the
-      # same RENDER_EXTERNAL_URL + DB-publish pattern used for the MCP URL
-      # (migration 029) is the way.
-      - key: BRILLIANT_BASE_URL
+      # --- API outbound URL (internal Render network) ---
+      # Render's inter-service mesh does NOT TLS-terminate on internal hops
+      # (TLS is only at the public LB), so the MCP must call the API over
+      # plain HTTP at the service's internal hostname:port. We pull both
+      # pieces via `fromService` so this stays generic — an operator forking
+      # the Blueprint and renaming the API service only updates the `name:`
+      # reference; host/port resolve at deploy time.
+      #
+      # mcp/client.py composes `http://${BRILLIANT_API_HOST}:${BRILLIANT_API_PORT}`
+      # when both are set; falls back to BRILLIANT_BASE_URL for compose / dev.
+      - key: BRILLIANT_API_HOST
         fromService:
           type: web
           name: brilliant-api
           property: host
+      - key: BRILLIANT_API_PORT
+        fromService:
+          type: web
+          name: brilliant-api
+          property: port
 
-      # --- MCP self-URL ---
-      # MCP_PORT must match what Render binds; remote_server.py reads
-      # MCP_BASE_URL from its own $RENDER_EXTERNAL_URL at boot if unset.
-      # We still export MCP_BASE_URL using the self-hostname for clarity.
-      - key: MCP_PORT
-        value: "8001"
+      # --- MCP self-URL fallback ---
+      # remote_server.py prefers $RENDER_EXTERNAL_URL (Render auto-injects
+      # this on every web service); MCP_BASE_URL is the explicit override
+      # for compose / manual deploys. fromService here yields the bare
+      # internal service name only — kept as a tag, not a URL.
       - key: MCP_BASE_URL
         fromService:
           type: web

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1,0 +1,213 @@
+"""Integration tests for ``GET /import/visualize`` (Sprint 0047, T-0273/T-0275).
+
+Four scenarios mandated by the spec:
+
+  1. happy_path  — seeded org → 200 text/html with substituted graph data
+  2. unauthorized — no Bearer → 401
+  3. empty       — 0 entries → "Graph not ready" card
+  4. oversize    — > 3000 entries → "exceeds the demo visualization limits" card
+
+Each test uses an isolated org/user/api_key triple so we don't perturb the
+seeded ``org_demo`` knowledge base. Cleanup is best-effort in teardown.
+
+Prerequisites
+-------------
+  1. ``docker compose up -d --build``  (API on :8010, Postgres on :5442)
+  2. ``pip install -r tests/requirements-dev.txt``
+
+Run
+---
+  pytest tests/test_visualize.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+
+try:
+    import requests
+    _REQUESTS_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _REQUESTS_AVAILABLE = False
+
+try:
+    import psycopg
+    _PSYCOPG_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _PSYCOPG_AVAILABLE = False
+
+
+BASE_URL = os.environ.get("BRILLIANT_BASE_URL", "http://localhost:8010")
+DB_DSN = os.environ.get(
+    "BRILLIANT_DB_DSN",
+    "postgresql://postgres:dev@localhost:5442/brilliant",
+)
+REQUEST_TIMEOUT = 30.0
+
+
+def _api_available() -> bool:
+    if not _REQUESTS_AVAILABLE:
+        return False
+    try:
+        return requests.get(f"{BASE_URL}/health", timeout=2.0).status_code == 200
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _REQUESTS_AVAILABLE,
+        reason="requests not installed; pip install -r tests/requirements-dev.txt",
+    ),
+    pytest.mark.skipif(
+        not _PSYCOPG_AVAILABLE,
+        reason="psycopg not installed; pip install -r tests/requirements-dev.txt",
+    ),
+    pytest.mark.skipif(
+        not _api_available(),
+        reason=f"Brilliant API not reachable at {BASE_URL} "
+        f"(start `docker compose up -d`).",
+    ),
+]
+
+
+def _provision_org(entry_count: int) -> tuple[str, str, str, str]:
+    """Create a fresh org + admin user + api_key, optionally seed entries.
+
+    Returns ``(org_id, user_id, key_prefix, plaintext_token)``. The caller
+    should pass ``key_prefix`` to ``_cleanup_org`` in a finally block.
+    """
+    suffix = uuid.uuid4().hex[:8]
+    org_id = f"org_viz_{suffix}"
+    user_id = f"usr_viz_{suffix}"
+    key_prefix = f"bkai_{suffix[:4]}"
+    token = f"{key_prefix}_testkey_viz_{suffix}"
+
+    with psycopg.connect(DB_DSN, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO organizations (id, name) VALUES (%s, %s)",
+                (org_id, f"viz-test-{suffix}"),
+            )
+            cur.execute(
+                """
+                INSERT INTO users (id, org_id, display_name, email_hash, role)
+                VALUES (%s, %s, %s, %s, 'admin')
+                """,
+                (user_id, org_id, f"viz-{suffix}", suffix),
+            )
+            cur.execute(
+                """
+                INSERT INTO api_keys (user_id, org_id, key_hash, key_prefix,
+                                      key_type, label)
+                VALUES (%s, %s, crypt(%s, gen_salt('bf')), %s,
+                        'interactive', %s)
+                """,
+                (user_id, org_id, token, key_prefix, f"viz-test-{suffix}"),
+            )
+            if entry_count > 0:
+                # Bulk insert via generate_series — fast even at 3001 rows.
+                cur.execute(
+                    """
+                    INSERT INTO entries (
+                        org_id, title, content, content_hash, content_type,
+                        logical_path, created_by, updated_by, source
+                    )
+                    SELECT
+                        %s,
+                        'viz-' || gs::text,
+                        'body ' || gs::text,
+                        encode(sha256(('viz-' || gs::text)::bytea), 'hex'),
+                        'context',
+                        %s || '/' || gs::text,
+                        %s, %s, 'api'
+                    FROM generate_series(1, %s) AS gs
+                    """,
+                    (org_id, f"viz-{suffix}", user_id, user_id, entry_count),
+                )
+
+    return org_id, user_id, key_prefix, token
+
+
+def _cleanup_org(org_id: str, key_prefix: str) -> None:
+    with psycopg.connect(DB_DSN, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM api_keys WHERE key_prefix = %s", (key_prefix,))
+            cur.execute("DELETE FROM entry_links WHERE source_entry_id IN "
+                        "(SELECT id FROM entries WHERE org_id = %s)", (org_id,))
+            cur.execute("DELETE FROM entries WHERE org_id = %s", (org_id,))
+            cur.execute("DELETE FROM users WHERE org_id = %s", (org_id,))
+            cur.execute("DELETE FROM organizations WHERE id = %s", (org_id,))
+
+
+@pytest.fixture
+def fresh_org():
+    """Factory fixture: callers request entry_count, get back a token."""
+    created: list[tuple[str, str]] = []
+
+    def _make(entry_count: int) -> str:
+        org_id, _user_id, key_prefix, token = _provision_org(entry_count)
+        created.append((org_id, key_prefix))
+        return token
+
+    yield _make
+
+    for org_id, key_prefix in created:
+        try:
+            _cleanup_org(org_id, key_prefix)
+        except Exception:
+            pass
+
+
+def _get_visualize(token: str | None) -> requests.Response:
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    return requests.get(
+        f"{BASE_URL}/import/visualize",
+        headers=headers,
+        timeout=REQUEST_TIMEOUT,
+    )
+
+
+def test_unauthorized_returns_401(fresh_org):
+    resp = _get_visualize(token=None)
+    assert resp.status_code == 401
+
+
+def test_happy_path_renders_template_with_substituted_data(fresh_org):
+    token = fresh_org(5)
+    resp = _get_visualize(token)
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    body = resp.text
+    # Placeholder must be fully substituted.
+    assert "__GRAPH_DATA_JSON__" not in body
+    # Graph payload must be present.
+    assert '"nodes"' in body
+    assert '"edges"' in body
+    # Brand chrome stays.
+    assert "Brilliant" in body or "xiReactor" in body
+
+
+def test_empty_org_renders_not_ready_card(fresh_org):
+    token = fresh_org(0)
+    resp = _get_visualize(token)
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    assert "Graph not ready" in resp.text
+
+
+def test_oversize_org_renders_demo_limits_card(fresh_org):
+    # 3001 > _VIZ_NODE_CAP (3000) → server short-circuits to OVERSIZE card
+    # before ever loading the heavy template.
+    token = fresh_org(3001)
+    resp = _get_visualize(token)
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    assert "exceeds the demo visualization limits" in resp.text
+    # OVERSIZE branch must NOT render the heavy template.
+    assert "__GRAPH_DATA_JSON__" not in resp.text
+    assert '"nodes"' not in resp.text

--- a/tools/render_migrate.py
+++ b/tools/render_migrate.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import os
 import re
 import sys
+import time
 from pathlib import Path
 
 import psycopg
@@ -87,6 +88,42 @@ def _migration_number(filename: str) -> int:
     return int(m.group(1)) if m else -1
 
 
+def _wait_for_db(dsn: str, timeout_s: int = 120, retry_delay_s: int = 3) -> None:
+    """Block until the DB accepts connections, or raise after timeout_s.
+
+    Render Blueprint deploys do not strictly order brilliant-db ready
+    before brilliant-api's preDeployCommand fires — a fresh Blueprint
+    sync can hit this script while the DB is still warming up. Without
+    a wait, the first deploy always fails with `Connection refused`
+    and Render auto-retries ~30s later. The visible "exited with
+    status 1" phase is awkward during demos.
+    """
+    deadline = time.time() + timeout_s
+    attempt = 0
+    last_exc: Exception | None = None
+    while time.time() < deadline:
+        attempt += 1
+        try:
+            with psycopg.connect(dsn, connect_timeout=5) as conn:
+                conn.close()
+            if attempt > 1:
+                print(f"DB ready after {attempt} attempts.", file=sys.stderr)
+            return
+        except psycopg.OperationalError as exc:
+            last_exc = exc
+            remaining = int(deadline - time.time())
+            print(
+                f"DB not ready (attempt {attempt}, {remaining}s left): "
+                f"{exc.__class__.__name__}; retrying in {retry_delay_s}s...",
+                file=sys.stderr,
+            )
+            time.sleep(retry_delay_s)
+    raise RuntimeError(
+        f"DB not ready after {timeout_s}s ({attempt} attempts). "
+        f"Last error: {last_exc}"
+    )
+
+
 def main() -> int:
     dsn = os.environ.get("DATABASE_URL")
     if not dsn:
@@ -108,6 +145,12 @@ def main() -> int:
     if not migration_files:
         print(f"ERROR: no *.sql files found in {MIGRATIONS_DIR}", file=sys.stderr)
         return 1
+
+    # Wait for the DB to be ready. On a fresh Blueprint deploy the API's
+    # preDeployCommand can fire before brilliant-db is accepting
+    # connections (Render has no inter-service depends_on). Retry for
+    # up to 120s instead of failing on the first connection refused.
+    _wait_for_db(dsn)
 
     # Phase 1: ensure tracking table exists (autocommit, so the DDL commits
     # even if the per-migration loop aborts).


### PR DESCRIPTION
## Summary
- **Sprint 0047 — 3D KB preview Easter egg (T-0273/0274/0275):** new `GET /import/visualize` endpoint serves a self-contained branded 3D graph (caps 3000 nodes / 4000 edges, empty/error fallback), plus the "✨ See it in 3D" link on `/import/vault` success panel. Tests in `tests/test_visualize.py` (4 scenarios).
- **Render Blueprint deploy hardening (wet-test fallout):** PORT envs to kill the port-detect loop; `BRILLIANT_API_HOST`+`PORT` via `fromService` (Render mesh is plain HTTP); MCP `preDeployCommand` polls `pg_roles` for `kb_admin` to wait on API migrations; HEAD `/` handler on both api+mcp for Render's edge probe; dockerCommand removed in favor of Dockerfile CMD; brilliant-db pinned to virginia.
- **Demo polish:** login submit-button loading state across 3 forms (kills double-click 400s), DarkReader fix on brand title (`currentColor` + CSS color anchor), Render boot-ready banner now at `logger.warning` so it actually surfaces on Render.

## Test plan
- [ ] Wet-test on Render off this branch (api + mcp dashboard branches already flipped)
- [ ] Verify `/import/visualize` renders for a real org with imported vault
- [ ] Confirm boot banner appears in Render logs at startup
- [ ] V2 demo recording uses this build

🤖 Generated with [Claude Code](https://claude.com/claude-code)