### PR TITLE
fix(render): disable autoDeploy to protect skill/API contract coupling

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -44,6 +44,13 @@ services:
     runtime: docker
     plan: starter
     region: virginia
+    # autoDeploy: false — Brilliant's API contract is coupled to the locally
+    # installed Claude skill bundle on each operator's machine. Auto-deploying
+    # every push to the tracked branch can introduce MCP tool/contract changes
+    # that the user's skill hasn't picked up yet, silently breaking their setup.
+    # Operators trigger "Manual Deploy" from the Render dashboard *after*
+    # updating their skill bundle to a compatible version.
+    autoDeploy: false
     dockerfilePath: ./api/Dockerfile
     dockerContext: .
     # NO `dockerCommand:` — Render's parser wraps the value in literal
@@ -136,6 +143,9 @@ services:
     runtime: docker
     plan: starter
     region: virginia
+    # autoDeploy: false — see brilliant-api above. MCP tool surface is the
+    # contract the Claude skill calls; auto-deploys can break skill compatibility.
+    autoDeploy: false
     dockerfilePath: ./mcp/Dockerfile
     dockerContext: ./mcp
     # Dockerfile CMD `python remote_server.py` is fine for production —


### PR DESCRIPTION
## Summary
- Adds `autoDeploy: false` to both `brilliant-api` and `brilliant-mcp` services in render.yaml
- Existing user instances tracking \`main\` will pick this up on their next sync (one final auto-deploy turns off all future auto-deploys)
- New deploys will require operators to click \"Manual Deploy\" in their Render dashboard

## Why
Render auto-deploys every push to the tracked branch, but the locally installed Claude skill bundle on each operator's machine does NOT auto-update. A breaking MCP tool or API contract change shipped to main would silently break deployed user instances. With autoDeploy off, the operator stays in control of when to upgrade — ideally after pulling the latest skill bundle.

This is a stop-gap. Follow-up work will introduce a release branch + \`/version\` handshake so the skill can warn users when an upgrade is available and refuse to run on incompatible API versions.

## Test plan
- [ ] Merge to dev, then dev → main, tag v0.6.1
- [ ] Confirm own Render deploy receives the change (one final auto-deploy)
- [ ] Push a no-op commit to main and confirm no auto-deploy fires
- [ ] Confirm \"Manual Deploy\" button still works in Render dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)